### PR TITLE
47 standardise npd output variables across eorca1 eorca12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ data/INPUT_eORCA12
 scripts/compile_nemo
 scripts/compile_tools
 scripts/python/mkslurm_NPD
+tools/INITIAL_CONDITIONS/data
+tools/INITIAL_CONDITIONS/dev
 
 
 # Created by https://www.toptal.com/developers/gitignore/api/jupyternotebooks,fortran,svn,matlab,python,emacs,vim

--- a/cfgs/GLOBAL_QCO/eORCA025/namelist_cfg
+++ b/cfgs/GLOBAL_QCO/eORCA025/namelist_cfg
@@ -37,9 +37,9 @@
 &namtsd
     cn_dir = './INPUT/',
 	ln_tsd_init = .false.,
-    sn_tem = 'EN.4.1.1.f.analysis.g10.1995-2014.eORCA025_v4.2.teos10.nc', -1, 'temperature', .true., .true., 'yearly',
+    sn_tem = 'woa23_decav71A0_TS_TEOS10_eORCA025.nc', -1, 'temperature', .true., .true., 'yearly',
              '', '', '',
-    sn_sal = 'EN.4.1.1.f.analysis.g10.1995-2014.eORCA025_v4.2.teos10.nc', -1, 'salinity', .true., .true., 'yearly',
+    sn_sal = 'woa23_decav71A0_TS_TEOS10_eORCA025.nc', -1, 'salinity', .true., .true., 'yearly',
              '', '', '',
 /
 
@@ -84,7 +84,7 @@
     nn_sssr = 2,
     rn_deds = -33.3333333,
     cn_dir = './INPUT/',
-    sn_sss = 'sss_1m_teos10_v4.2.nc', -1, 'salinity', .true., .true., 'yearly',
+    sn_sss = 'woa23_decav91C0_sss_TEOS10_eORCA025.nc', -1, 'salinity', .true., .true., 'yearly',
              '', '', '',
 /
 
@@ -234,3 +234,6 @@
     ln_diacfl = .true.,
 /
 
+&namtrd
+    ln_tra_trd = .true.,
+/

--- a/cfgs/GLOBAL_QCO/eORCA1/namelist_cfg
+++ b/cfgs/GLOBAL_QCO/eORCA1/namelist_cfg
@@ -33,9 +33,9 @@
 &namtsd
     cn_dir = './INPUT/',
 	ln_tsd_init = .false.,
-    sn_tem = 'EN4_v1.1.1995_2014.monthlymean_eORCA1_NEMO_L75_teos10.nc', -1, 'temperature', .true., .true., 'yearly',
+    sn_tem = 'woa23_decav71A0_TS_TEOS10_eORCA1.nc', -1, 'temperature', .true., .true., 'yearly',
              '', '', '',
-    sn_sal = 'EN4_v1.1.1995_2014.monthlymean_eORCA1_NEMO_L75_teos10.nc', -1, 'salinity', .true., .true., 'yearly',
+    sn_sal = 'woa23_decav71A0_TS_TEOS10_eORCA1.nc', -1, 'salinity', .true., .true., 'yearly',
              '', '', '',
 /
 
@@ -80,7 +80,7 @@
     nn_sssr = 2,
     rn_deds = -33.3333333,
     cn_dir = './INPUT/',
-    sn_sss = 'sss_1m_EN4_eORCA1_teos10.nc', -1, 'salinity', .true., .true., 'yearly',
+    sn_sss = 'woa23_decav91C0_sss_TEOS10_eORCA1.nc', -1, 'salinity', .true., .true., 'yearly',
              '', '', '',
 /
 
@@ -225,5 +225,9 @@
     sn_cfctl%l_runstat = .true.,
     ln_timing = .true.,
     ln_diacfl = .true.,
+/
+
+&namtrd
+    ln_tra_trd = .true.,
 /
 

--- a/cfgs/GLOBAL_QCO/eORCA12/namelist_cfg
+++ b/cfgs/GLOBAL_QCO/eORCA12/namelist_cfg
@@ -2,17 +2,20 @@
 
 &namrun
     cn_exp = 'eORCA12',
-    nn_it000 = 'CHANGEME',
-    nn_itend = 'CHANGEME',
-    nn_date0 = 20060101,
-    ln_rstart = 'CHANGEME',
+	nn_it000 = CHANGEME,
+	nn_itend = CHANGEME,
+    nn_date0 = 19760101,
+	ln_rstart = CHANGEME,
         ln_reset_ts=.false.,
+    nn_leapy = 1,
     nn_rstctl = 2,
-    cn_ocerst_in = 'CHANGEME',
+	cn_ocerst_in = 'CHANGEME',
     cn_ocerst_indir = './RESTARTS',
     cn_ocerst_outdir = './RESTARTS',
-    ln_mskland = .false.,
-    ln_cfmeta = .true.,
+    nn_stock = 70128,
+    ln_mskland = .true.,
+    ln_rst_list = .false.
+    nn_stocklist = 0,0,0,0,0,0,0,0,0,0
 /
 
 &namdom
@@ -27,11 +30,11 @@
 /
 
 &namtsd
-    ln_tsd_init = 'CHANGEME',
     cn_dir = './INPUT/',
-    sn_tem = 'g8p7ho_tsd_init_filled', 24.0, 'tn', .false., .false., 'daily',
+	ln_tsd_init = .false.,
+    sn_tem = 'woa23_decav71A0_TS_TEOS10_eORCA12.nc', -1, 'temperature', .true., .true., 'yearly',
              '', '', '',
-    sn_sal = 'g8p7ho_tsd_init_filled', 24.0, 'sn', .false., .false., 'daily',
+    sn_sal = 'woa23_decav71A0_TS_TEOS10_eORCA12.nc', -1, 'salinity', .true., .true., 'yearly',
              '', '', '',
 /
 
@@ -75,8 +78,8 @@
     nn_sssr = 2,
     rn_deds = -33.3333333,
     cn_dir = './INPUT/',
-    sn_sss = 'sss_1m.nc', -1, 'salinity', .true., .true., 'yearly', '',
-             '', '',
+    sn_sss = 'woa23_decav91C0_sss_TEOS10_eORCA12.nc', -1, 'salinity', .true., .true., 'yearly',
+             '', '', '',
 /
 
 &namsbc_rnf
@@ -178,3 +181,6 @@
     ln_timing = .true.,
 /
 
+&namtrd
+    ln_tra_trd = .true.,
+/

--- a/cfgs/SHARED/file_def_nemo-oce_1d_C6.xml
+++ b/cfgs/SHARED/file_def_nemo-oce_1d_C6.xml
@@ -13,35 +13,35 @@
       <file_group id="1d" output_freq="1d"  split_freq="1mo" output_level="10" enabled=".TRUE.">  <!-- 1d files -->   
 
 	<file id="file1" mode="write" writer="t1dwriter" gatherer="tgatherer" using_server2="true" name_suffix="_grid_T" description="ocean T grid variables" >
-          <field field_ref="sst_con"         name="tos_con"   standard_name="sea_surface_temperature"                                 />
-          <field field_ref="sst2_con"        name="tossq_con"   />
+          <field field_ref="sst_con"         name="tos_con"   standard_name="sea_surface_temperature" />
+          <field field_ref="sst2_con"        name="tossq_con" />
           <field field_ref="sss2_abs"        name="sossq_abs" long_name="Square of Sea Surface Salinity"   standard_name="square_of_sea_surface_Salinity" />
-          <field field_ref="sss_abs"         name="sos_abs"   standard_name="sea_surface_salinity"                                    />
-          <field field_ref="mldr0_3"         name="mlotst"    long_name="Ocean Mixed Layer Thickness Defined by Sigma T"         />
-	  <field field_ref="ssh"             name="zos"       standard_name="sea_surface_height_above_geoid" long_name="Sea Surface Height Above Geoid"      />
-          <field field_ref="botpres"         name="pbo"                                                                                />
+          <field field_ref="sss_abs"         name="sos_abs"   standard_name="sea_surface_salinity" />
+          <field field_ref="mldr0_3"         name="mlotst"    long_name="Ocean Mixed Layer Thickness Defined by Sigma T" />
+          <field field_ref="ssh"             name="zos"       standard_name="sea_surface_height_above_geoid" long_name="Sea Surface Height Above Geoid" />
+          <field field_ref="botpres"         name="pbo" />
 <!-- TO FIX
           <field field_ref="20d"             name="t20d"  standard_name="depth_of_isosurface_of_sea_water_potential_temperature" />
 -->
 	</file>
 	
 	<file id="file2" mode="write" writer="u1dwriter" gatherer="ugatherer" using_server2="true" name_suffix="_grid_U" description="ocean U grid variables" enabled=".TRUE." >
-          <field field_ref="ssu"             name="sozocrtx"   standard_name="sea_surface_eastward_sea_water_velocity"                 />
-	  <field field_ref="utau"            name="sozotaux"   standard_name="surface_downward_x_stress" />
+          <field field_ref="ssu"             name="sozocrtx"   standard_name="sea_surface_eastward_sea_water_velocity" />
+          <field field_ref="utau"            name="sozotaux"   standard_name="surface_downward_x_stress" />
 	</file>
 	
 	<file id="file3" mode="write" writer="v1dwriter" gatherer="ugatherer" using_server2="true" name_suffix="_grid_V" description="ocean V grid variables"  enabled=".TRUE." >
-          <field field_ref="ssv"             name="somecrty"   standard_name="sea_surface_northward_sea_water_velocity"                 />
-	  <field field_ref="vtau"            name="sometauy"   standard_name="surface_downward_y_stress" />
+          <field field_ref="ssv"             name="somecrty"   standard_name="sea_surface_northward_sea_water_velocity" />
+          <field field_ref="vtau"            name="sometauy"   standard_name="surface_downward_y_stress" />
 	</file>
 
         <file id="file9" mode="write" writer="s1dwriter" gatherer="tgatherer" using_server2="true" compression_level="0" name_suffix="_scalar" description="scalar variables"  enabled=".TRUE." >
 <!-- TO FIX
           <field field_ref="sshthster"       name="scsshtst"   />
 -->
-          <field field_ref="voltot"          name="scvoltot"   />
-          <field field_ref="temptot"         name="thetaoga"   />
-          <field field_ref="saltot"          name="soga"   />
+          <field field_ref="voltot"          name="scvoltot" />
+          <field field_ref="temptot"         name="thetaoga" />
+          <field field_ref="saltot"          name="soga" />
         </file>
 
       </file_group>

--- a/cfgs/SHARED/file_def_nemo-oce_1m_C6.xml
+++ b/cfgs/SHARED/file_def_nemo-oce_1m_C6.xml
@@ -23,21 +23,31 @@
           <field field_ref="toce_vmean300"   name="thetaot300"   />
 -->
           <field field_ref="soce_abs"        name="so_abs"       operation="average" freq_op="1mo" > @soce_abs_e3t / @e3t </field>
-	        <field field_ref="ssh"             name="zos"          standard_name="sea_surface_height_above_geoid" long_name="Sea Surface Height Above Geoid"      />
-          <field field_ref="ssh2"            name="zossq"        standard_name="square_of_sea_surface_height_above_geoid" long_name="Square of Sea Surface Height Above Geoid"  />
-	        <field field_ref="runoffs"         name="friver"       standard_name="water_flux_into_sea_water_from_rivers"                     />
-	        <field field_ref="qt"              name="hfds"         standard_name="surface_downward_heat_flux_in_sea_water"                     />
-	        <field field_ref="qsr3d"           name="rsdo"         standard_name="downwelling_shortwave_flux_in_sea_water"                     />
-          <field field_ref="mldr0_3"         name="mlotst"       long_name="Ocean Mixed Layer Thickness Defined by Sigma T"         />
+	        <field field_ref="ssh"             name="zos"          standard_name="sea_surface_height_above_geoid" long_name="Sea Surface Height Above Geoid" />
+          <field field_ref="ssh2"            name="zossq"        standard_name="square_of_sea_surface_height_above_geoid" long_name="Square of Sea Surface Height Above Geoid" />
+	        <field field_ref="runoffs"         name="friver"       standard_name="water_flux_into_sea_water_from_rivers" />
+          <field field_ref="qt"              name="hfto"        standard_name="surface_net_downward_total_heat_flux" />
+          <field field_ref="qsr"             name="hfsr"        standard_name="surface_net_downward_solar_heat_flux" />
+          <field field_ref="qns"             name="hfns"        standard_name="surface_net_downward_non_solar_heat_flux" />
+          <field field_ref="qsr3d"           name="rsdo"        standard_name="downwelling_shortwave_flux_in_sea_water" />
+
+          <field field_ref="qt_oce"          name="hfds"    standard_name="ocean_surface_downward_total_heat_flux" />
+          <field field_ref="qlw_oce"         name="rlntds"  standard_name="ocean_surface_net_downward_longwave_heat_flux" />
+          <field field_ref="qsb_oce"         name='hfss'    standard_name="ocean_surface_downward_sensible_heat_flux" />
+          <field field_ref="qla_oce"         name="hfls"    standard_name="ocean_surface_downward_latent_heat_flux" />
+          <field field_ref="qemp_oce"        name="hfempds" standard_name="ocean_surface_downward_heat_flux_from_E-P" />
+          <field field_ref="qsr_oce"         name="rsntds"  standard_name="ocean_surface_net_downward_shortwave_heat_flux" />
+
+          <field field_ref="mldr0_3"         name="mlotst"       long_name="Ocean Mixed Layer Thickness Defined by Sigma T" />
           <field field_ref="mldr0_3"         name="mlotstsq"     long_name="Square of Ocean Mixed Layer Thickness Defined by Sigma T"  standard_name="square_of_ocean_mixed_layer_thickness_defined_by_sigma_theta" > mldr0_3 * mldr0_3 </field>
-          <field field_ref="mldr0_3"         name="mlotstmax"    long_name="Ocean Mixed Layer Thickness Defined by Sigma T" operation="maximum"        />
-          <field field_ref="mldr0_3"         name="mlotstmin"    long_name="Ocean Mixed Layer Thickness Defined by Sigma T" operation="minimum"        />
-          <field field_ref="berg_melt"       name="ficeberg"     standard_name="water_flux_into_sea_water_from_icebergs"      />
-          <field field_ref="berg_melt_qlat"  name="berg_latent_heat_flux"     standard_name="latent_heat_flux_from_icebergs"                                 />
-          <field field_ref="botpres"         name="pbo"                                                                                />
-          <field field_ref="sst_con"         name="tos_con"      standard_name="sea_surface_temperature"                                 />
-          <field field_ref="sst2_con"        name="tossq_con"   />
-          <field field_ref="sss_abs"         name="sos_abs"      standard_name="sea_surface_salinity"                                    />
+          <field field_ref="mldr0_3"         name="mlotstmax"    long_name="Ocean Mixed Layer Thickness Defined by Sigma T" operation="maximum" />
+          <field field_ref="mldr0_3"         name="mlotstmin"    long_name="Ocean Mixed Layer Thickness Defined by Sigma T" operation="minimum" />
+          <field field_ref="berg_melt"       name="ficeberg"     standard_name="water_flux_into_sea_water_from_icebergs" />
+          <field field_ref="berg_melt_qlat"  name="berg_latent_heat_flux"     standard_name="latent_heat_flux_from_icebergs" />
+          <field field_ref="botpres"         name="pbo" />
+          <field field_ref="sst_con"         name="tos_con"      standard_name="sea_surface_temperature" />
+          <field field_ref="sst2_con"        name="tossq_con" />
+          <field field_ref="sss_abs"         name="sos_abs"      standard_name="sea_surface_salinity" />
           <field field_ref="sss2_abs"        name="sossq_abs"   long_name="Square of Sea Surface Salinity"   standard_name="square_of_sea_surface_Salinity" />
 <!-- TO FIX
           <field field_ref="rain_ao_cea" name="pr" standard_name="rainfall_flux" long_name="Rainfall Flux" > @rain_ao_cea </field>
@@ -48,7 +58,7 @@
           <field field_ref="hflx_evap_cea"   name="hfevapds" long_name="Temperature Flux due to Evaporation Expressed as Heat Flux Out of Sea Water" standard_name="temperature_flux_due_to_evaporation_expressed_as_heat_flux_out_of_sea_water" />
           <field field_ref="hflx_rnf_cea"    name="hflx_rnf" long_name="Temperature Flux due to Runoff Expressed as Heat Flux into  Sea Water" standard_name="temperature_flux_due_to_runoff_expressed_as_heat_flux_into_sea_water" > hflx_rnf_cea </field> 
           <field field_ref="saltflx"         name="sfdsi" standard_name="downward_sea_ice_basal_salt_flux" />
-          <field field_ref="fmmflx"          name="fsitherm"      unit="kg/m2/s"   />
+          <field field_ref="fmmflx"          name="fsitherm"      unit="kg/m2/s" />
           <field field_ref="empmr" > @empmr + @fwfisf </field>
 <!-- TO FIX
           <field field_ref="Age" name="agessc" />
@@ -56,19 +66,19 @@
           <field field_ref="tnpeo" />
           <field field_ref="snowpre"         name="snowpre" />
           <field field_ref="snow_ai_cea"     name="snow_ai_cea" />
-	        <field field_ref="empmr"           name="sowaflup"   standard_name="water_flux_out_of_sea_ice_and_sea_water"                 />
-	        <field field_ref="saltflx"         name="sosafldo"   standard_name="salt_flux_into_sea_water"                                />
-          <field field_ref="mldkz5"          name="somixhgt"   standard_name="ocean_mixed_layer_thickness_defined_by_vertical_tracer_diffusivity"   />
-          <field field_ref="mldr10_1"        name="somxl010"   standard_name="ocean_mixed_layer_thickness_defined_by_sigma_theta"      />
-          <field field_ref="mldzint_1"       name="somxzint1"  standard_name="ocean_mixed_layer_thickness_defined_by_sigma_theta"      />
-          <field field_ref="ice_cover"       name="soicecov"   standard_name="sea_ice_area_fraction"                                   />
-          <field field_ref="wspd"            name="sowindsp"   standard_name="wind_speed"                                              />          
-          <field field_ref="qlatisf"         name="sohflisf"   standard_name=""                                                        />
-          <field field_ref="qlatisf3d_par"   name="vohflisf"   standard_name=""                                                        />
-          <field field_ref="qhcisf"          name="sohfcisf"   standard_name=""                                                        />
-          <field field_ref="qhcisf3d_par"    name="vohfcisf"   standard_name=""                                                        />
-          <field field_ref="fwfisf"          name="sowflisf"   standard_name=""                                                        />
-          <field field_ref="fwfisf3d_par"    name="vowflisf"   standard_name=""                                                        />
+	        <field field_ref="empmr"           name="sowaflup"   standard_name="water_flux_out_of_sea_ice_and_sea_water" />
+	        <field field_ref="saltflx"         name="sosafldo"   standard_name="salt_flux_into_sea_water" />
+          <field field_ref="mldkz5"          name="somixhgt"   standard_name="ocean_mixed_layer_thickness_defined_by_vertical_tracer_diffusivity" />
+          <field field_ref="mldr10_1"        name="somxl010"   standard_name="ocean_mixed_layer_thickness_defined_by_sigma_theta" />
+          <field field_ref="mldzint_1"       name="somxzint1"  standard_name="ocean_mixed_layer_thickness_defined_by_sigma_theta" />
+          <field field_ref="ice_cover"       name="soicecov"   standard_name="sea_ice_area_fraction" />
+          <field field_ref="wspd"            name="sowindsp"   standard_name="wind_speed" />          
+          <field field_ref="qlatisf"         name="sohflisf"   standard_name="" />
+          <field field_ref="qlatisf3d_par"   name="vohflisf"   standard_name="" />
+          <field field_ref="qhcisf"          name="sohfcisf"   standard_name="" />
+          <field field_ref="qhcisf3d_par"    name="vohfcisf"   standard_name="" />
+          <field field_ref="fwfisf"          name="sowflisf"   standard_name="" />
+          <field field_ref="fwfisf3d_par"    name="vowflisf"   standard_name="" />
 <!-- TO FIX
           <field field_ref="ketrd_ldf_vsum"     name="dispkexyfo"   standard_name="Dissipation of kinetic energy by lateral viscosity" grid_ref="vert_sum"/>
 -->
@@ -105,7 +115,7 @@
           <field field_ref="e3u"             name="e3u"     standard_name="cell_thickness" />
           <field field_ref="uoce"            name="uo"      operation="average" freq_op="1mo" > @uoce_e3u / @e3u </field>
 	        <field field_ref="uoce_eiv"        name="uo_eiv"  operation="average" freq_op="1mo" />
-	        <field field_ref="utau"            name="tauuo"   standard_name="surface_downward_x_stress"  />
+	        <field field_ref="utau"            name="tauuo"   standard_name="surface_downward_x_stress" />
 <!-- TO FIX
           <field field_ref="ut"              name="uto" standard_name="product_of_xward_sea_water_velocity_and_temperature" long_name="UT"  operation="average" freq_op="1mo" > @ut_e3u / @e3u </field>
           <field field_ref="us"              name="uso" standard_name="product_of_xward_sea_water_velocity_and_salinity" long_name="US"    operation="average" freq_op="1mo" > @us_e3u / @e3u </field>
@@ -142,13 +152,13 @@
 	
 	<file id="file13" mode="write" writer="w1mwriter" gatherer="tgatherer" using_server2="true" name_suffix="_grid_W" description="ocean W grid variables" >
           <field field_ref="e3w"             name="e3w"      standard_name="cell_thickness" />
-	        <field field_ref="avt"             name="difvho"   standard_name="ocean_vertical_heat_diffusivity"  />
-	        <field field_ref="avs"             name="difvso"   standard_name="ocean_vertical_salt_diffusivity"   />                 
-          <field field_ref="avm"             name="difvmo"   standard_name="ocean_vertical_momentum_diffusivity"               />
-          <field field_ref="avt_evd"         name="avt_evd"  standard_name="enhanced_vertical_heat_diffusivity"               />
-          <field field_ref="av_tmx"          name="diftrto"  standard_name="ocean_vertical_tracer_diffusivity_due_to_tides"               />
+	        <field field_ref="avt"             name="difvho"   standard_name="ocean_vertical_heat_diffusivity" />
+	        <field field_ref="avs"             name="difvso"   standard_name="ocean_vertical_salt_diffusivity" />                 
+          <field field_ref="avm"             name="difvmo"   standard_name="ocean_vertical_momentum_diffusivity" />
+          <field field_ref="avt_evd"         name="avt_evd"  standard_name="enhanced_vertical_heat_diffusivity" />
+          <field field_ref="av_tmx"          name="diftrto"  standard_name="ocean_vertical_tracer_diffusivity_due_to_tides" />
           <field field_ref="w_masstr"        name="wmo" />
-	        <field field_ref="woce"            name="wo"       standard_name="upward_sea_water_velocity" long_name="W"                  />
+	        <field field_ref="woce"            name="wo"       standard_name="upward_sea_water_velocity" long_name="W" />
           <field field_ref="woce"            name="w2o"      standard_name="square_of_upward_sea_water_velocity" long_name="WW"  operation="average" > woce * woce </field>
           <field field_ref="bn2"             name="obvfsq" />
 <!-- TO FIX
@@ -159,9 +169,9 @@
 	</file>
 	
         <file id="file14" mode="write" writer="s1mwriter" gatherer="tgatherer" using_server2="true" compression_level="0" name_suffix="_scalar" description="scalar variables" enabled=".true." >
-          <field field_ref="voltot"          name="scvoltot"   />
-          <field field_ref="temptot"         name="thetaoga"   />
-          <field field_ref="saltot"          name="soga"   />
+          <field field_ref="voltot"          name="scvoltot" />
+          <field field_ref="temptot"         name="thetaoga" />
+          <field field_ref="saltot"          name="soga" />
         </file>
 
       </file_group>

--- a/cfgs/SHARED/file_def_nemo-oce_1y_C6.xml
+++ b/cfgs/SHARED/file_def_nemo-oce_1y_C6.xml
@@ -23,21 +23,31 @@
           <field field_ref="toce_vmean300"   name="thetaot300"   />
 -->
           <field field_ref="soce_abs"        name="so_abs"       operation="average" freq_op="1y" > @soce_abs_e3t / @e3t </field>
-	        <field field_ref="ssh"             name="zos"          standard_name="sea_surface_height_above_geoid" long_name="Sea Surface Height Above Geoid"      />
-          <field field_ref="ssh2"            name="zossq"        standard_name="square_of_sea_surface_height_above_geoid" long_name="Square of Sea Surface Height Above Geoid"  />
-	        <field field_ref="runoffs"         name="friver"       standard_name="water_flux_into_sea_water_from_rivers"                     />
-	        <field field_ref="qt"              name="hfds"         standard_name="surface_downward_heat_flux_in_sea_water"                     />
-	        <field field_ref="qsr3d"           name="rsdo"         standard_name="downwelling_shortwave_flux_in_sea_water"                     />
-          <field field_ref="mldr0_3"         name="mlotst"       long_name="Ocean Mixed Layer Thickness Defined by Sigma T"         />
+	        <field field_ref="ssh"             name="zos"          standard_name="sea_surface_height_above_geoid" long_name="Sea Surface Height Above Geoid" />
+          <field field_ref="ssh2"            name="zossq"        standard_name="square_of_sea_surface_height_above_geoid" long_name="Square of Sea Surface Height Above Geoid" />
+	        <field field_ref="runoffs"         name="friver"       standard_name="water_flux_into_sea_water_from_rivers" />
+          <field field_ref="qt"              name="hfto"        standard_name="surface_net_downward_total_heat_flux" />
+          <field field_ref="qsr"             name="hfsr"        standard_name="surface_net_downward_solar_heat_flux" />
+          <field field_ref="qns"             name="hfns"        standard_name="surface_net_downward_non_solar_heat_flux" />
+          <field field_ref="qsr3d"           name="rsdo"        standard_name="downwelling_shortwave_flux_in_sea_water" />
+
+          <field field_ref="qt_oce"          name="hfds"    standard_name="ocean_surface_downward_total_heat_flux" />
+          <field field_ref="qlw_oce"         name="rlntds"  standard_name="ocean_surface_net_downward_longwave_heat_flux" />
+          <field field_ref="qsb_oce"         name='hfss'    standard_name="ocean_surface_downward_sensible_heat_flux" />
+          <field field_ref="qla_oce"         name="hfls"    standard_name="ocean_surface_downward_latent_heat_flux" />
+          <field field_ref="qemp_oce"        name="hfempds" standard_name="ocean_surface_downward_heat_flux_from_E-P" />
+          <field field_ref="qsr_oce"         name="rsntds"  standard_name="ocean_surface_net_downward_shortwave_heat_flux" />
+
+          <field field_ref="mldr0_3"         name="mlotst"       long_name="Ocean Mixed Layer Thickness Defined by Sigma T" />
           <field field_ref="mldr0_3"         name="mlotstsq"     long_name="Square of Ocean Mixed Layer Thickness Defined by Sigma T"  standard_name="square_of_ocean_mixed_layer_thickness_defined_by_sigma_theta" > mldr0_3 * mldr0_3 </field>
-          <field field_ref="mldr0_3"         name="mlotstmax"    long_name="Ocean Mixed Layer Thickness Defined by Sigma T" operation="maximum"        />
-          <field field_ref="mldr0_3"         name="mlotstmin"    long_name="Ocean Mixed Layer Thickness Defined by Sigma T" operation="minimum"        />
-          <field field_ref="berg_melt"       name="ficeberg"     standard_name="water_flux_into_sea_water_from_icebergs"      />
-          <field field_ref="berg_melt_qlat"  name="berg_latent_heat_flux"     standard_name="latent_heat_flux_from_icebergs"                                 />
-          <field field_ref="botpres"         name="pbo"                                                                                />
-          <field field_ref="sst_con"         name="tos_con"      standard_name="sea_surface_temperature"                                 />
-          <field field_ref="sst2_con"        name="tossq_con"   />
-          <field field_ref="sss_abs"         name="sos_abs"      standard_name="sea_surface_salinity"                                    />
+          <field field_ref="mldr0_3"         name="mlotstmax"    long_name="Ocean Mixed Layer Thickness Defined by Sigma T" operation="maximum" />
+          <field field_ref="mldr0_3"         name="mlotstmin"    long_name="Ocean Mixed Layer Thickness Defined by Sigma T" operation="minimum" />
+          <field field_ref="berg_melt"       name="ficeberg"     standard_name="water_flux_into_sea_water_from_icebergs" />
+          <field field_ref="berg_melt_qlat"  name="berg_latent_heat_flux"     standard_name="latent_heat_flux_from_icebergs" />
+          <field field_ref="botpres"         name="pbo" />
+          <field field_ref="sst_con"         name="tos_con"      standard_name="sea_surface_temperature" />
+          <field field_ref="sst2_con"        name="tossq_con" />
+          <field field_ref="sss_abs"         name="sos_abs"      standard_name="sea_surface_salinity" />
           <field field_ref="sss2_abs"        name="sossq_abs"   long_name="Square of Sea Surface Salinity"   standard_name="square_of_sea_surface_Salinity" />
 <!-- TO FIX
           <field field_ref="rain_ao_cea" name="pr" standard_name="rainfall_flux" long_name="Rainfall Flux" > @rain_ao_cea </field>
@@ -48,7 +58,7 @@
           <field field_ref="hflx_evap_cea"   name="hfevapds" long_name="Temperature Flux due to Evaporation Expressed as Heat Flux Out of Sea Water" standard_name="temperature_flux_due_to_evaporation_expressed_as_heat_flux_out_of_sea_water" />
           <field field_ref="hflx_rnf_cea"    name="hflx_rnf" long_name="Temperature Flux due to Runoff Expressed as Heat Flux into  Sea Water" standard_name="temperature_flux_due_to_runoff_expressed_as_heat_flux_into_sea_water" > hflx_rnf_cea </field> 
           <field field_ref="saltflx"         name="sfdsi" standard_name="downward_sea_ice_basal_salt_flux" />
-          <field field_ref="fmmflx"          name="fsitherm"      unit="kg/m2/s"   />
+          <field field_ref="fmmflx"          name="fsitherm"      unit="kg/m2/s" />
           <field field_ref="empmr" > @empmr + @fwfisf </field>
 <!-- TO FIX
           <field field_ref="Age" name="agessc" />
@@ -56,19 +66,19 @@
           <field field_ref="tnpeo" />
           <field field_ref="snowpre"         name="snowpre" />
           <field field_ref="snow_ai_cea"     name="snow_ai_cea" />
-	        <field field_ref="empmr"           name="sowaflup"   standard_name="water_flux_out_of_sea_ice_and_sea_water"                 />
-	        <field field_ref="saltflx"         name="sosafldo"   standard_name="salt_flux_into_sea_water"                                />
-          <field field_ref="mldkz5"          name="somixhgt"   standard_name="ocean_mixed_layer_thickness_defined_by_vertical_tracer_diffusivity"   />
-          <field field_ref="mldr10_1"        name="somxl010"   standard_name="ocean_mixed_layer_thickness_defined_by_sigma_theta"      />
-          <field field_ref="mldzint_1"       name="somxzint1"  standard_name="ocean_mixed_layer_thickness_defined_by_sigma_theta"      />
-          <field field_ref="ice_cover"       name="soicecov"   standard_name="sea_ice_area_fraction"                                   />
-          <field field_ref="wspd"            name="sowindsp"   standard_name="wind_speed"                                              />          
-          <field field_ref="qlatisf"         name="sohflisf"   standard_name=""                                                        />
-          <field field_ref="qlatisf3d_par"   name="vohflisf"   standard_name=""                                                        />
-          <field field_ref="qhcisf"          name="sohfcisf"   standard_name=""                                                        />
-          <field field_ref="qhcisf3d_par"    name="vohfcisf"   standard_name=""                                                        />
-          <field field_ref="fwfisf"          name="sowflisf"   standard_name=""                                                        />
-          <field field_ref="fwfisf3d_par"    name="vowflisf"   standard_name=""                                                        />
+	        <field field_ref="empmr"           name="sowaflup"   standard_name="water_flux_out_of_sea_ice_and_sea_water" />
+	        <field field_ref="saltflx"         name="sosafldo"   standard_name="salt_flux_into_sea_water" />
+          <field field_ref="mldkz5"          name="somixhgt"   standard_name="ocean_mixed_layer_thickness_defined_by_vertical_tracer_diffusivity" />
+          <field field_ref="mldr10_1"        name="somxl010"   standard_name="ocean_mixed_layer_thickness_defined_by_sigma_theta" />
+          <field field_ref="mldzint_1"       name="somxzint1"  standard_name="ocean_mixed_layer_thickness_defined_by_sigma_theta" />
+          <field field_ref="ice_cover"       name="soicecov"   standard_name="sea_ice_area_fraction" />
+          <field field_ref="wspd"            name="sowindsp"   standard_name="wind_speed" />          
+          <field field_ref="qlatisf"         name="sohflisf"   standard_name="" />
+          <field field_ref="qlatisf3d_par"   name="vohflisf"   standard_name="" />
+          <field field_ref="qhcisf"          name="sohfcisf"   standard_name="" />
+          <field field_ref="qhcisf3d_par"    name="vohfcisf"   standard_name="" />
+          <field field_ref="fwfisf"          name="sowflisf"   standard_name="" />
+          <field field_ref="fwfisf3d_par"    name="vowflisf"   standard_name="" />
 <!-- TO FIX
           <field field_ref="ketrd_ldf_vsum"     name="dispkexyfo"   standard_name="Dissipation of kinetic energy by lateral viscosity" grid_ref="vert_sum"/>
 -->
@@ -105,7 +115,7 @@
           <field field_ref="e3u"             name="e3u"     standard_name="cell_thickness" />
           <field field_ref="uoce"            name="uo"      operation="average" freq_op="1y" > @uoce_e3u / @e3u </field>
 	        <field field_ref="uoce_eiv"        name="uo_eiv"  operation="average" freq_op="1y" />
-	        <field field_ref="utau"            name="tauuo"   standard_name="surface_downward_x_stress"  />
+	        <field field_ref="utau"            name="tauuo"   standard_name="surface_downward_x_stress" />
 <!-- TO FIX
           <field field_ref="ut"              name="uto" standard_name="product_of_xward_sea_water_velocity_and_temperature" long_name="UT"  operation="average" freq_op="1y" > @ut_e3u / @e3u </field>
           <field field_ref="us"              name="uso" standard_name="product_of_xward_sea_water_velocity_and_salinity" long_name="US"    operation="average" freq_op="1y" > @us_e3u / @e3u </field>
@@ -142,13 +152,13 @@
 	
 	<file id="file23" mode="write" writer="w1ywriter" gatherer="tgatherer" using_server2="true" name_suffix="_grid_W" description="ocean W grid variables" >
           <field field_ref="e3w"             name="e3w"      standard_name="cell_thickness" />
-	        <field field_ref="avt"             name="difvho"   standard_name="ocean_vertical_heat_diffusivity"  />
-	        <field field_ref="avs"             name="difvso"   standard_name="ocean_vertical_salt_diffusivity"   />                 
-          <field field_ref="avm"             name="difvmo"   standard_name="ocean_vertical_momentum_diffusivity"               />
-          <field field_ref="avt_evd"         name="avt_evd"  standard_name="enhanced_vertical_heat_diffusivity"               />
-          <field field_ref="av_tmx"          name="diftrto"  standard_name="ocean_vertical_tracer_diffusivity_due_to_tides"               />
+	        <field field_ref="avt"             name="difvho"   standard_name="ocean_vertical_heat_diffusivity" />
+	        <field field_ref="avs"             name="difvso"   standard_name="ocean_vertical_salt_diffusivity" />                 
+          <field field_ref="avm"             name="difvmo"   standard_name="ocean_vertical_momentum_diffusivity" />
+          <field field_ref="avt_evd"         name="avt_evd"  standard_name="enhanced_vertical_heat_diffusivity" />
+          <field field_ref="av_tmx"          name="diftrto"  standard_name="ocean_vertical_tracer_diffusivity_due_to_tides" />
           <field field_ref="w_masstr"        name="wmo" />
-	        <field field_ref="woce"            name="wo"       standard_name="upward_sea_water_velocity" long_name="W"                  />
+	        <field field_ref="woce"            name="wo"       standard_name="upward_sea_water_velocity" long_name="W" />
           <field field_ref="woce"            name="w2o"      standard_name="square_of_upward_sea_water_velocity" long_name="WW"  operation="average" > woce * woce </field>
           <field field_ref="bn2"             name="obvfsq" />
 <!-- TO FIX
@@ -159,9 +169,9 @@
 	</file>
 	
         <file id="file24" mode="write" writer="s1ywriter" gatherer="tgatherer" using_server2="true" compression_level="0" name_suffix="_scalar" description="scalar variables" enabled=".true." >
-          <field field_ref="voltot"          name="scvoltot"   />
-          <field field_ref="temptot"         name="thetaoga"   />
-          <field field_ref="saltot"          name="soga"   />
+          <field field_ref="voltot"          name="scvoltot" />
+          <field field_ref="temptot"         name="thetaoga" />
+          <field field_ref="saltot"          name="soga" />
         </file>
 
       </file_group>

--- a/cfgs/SHARED/file_def_nemo-oce_5d_C6.xml
+++ b/cfgs/SHARED/file_def_nemo-oce_5d_C6.xml
@@ -23,21 +23,31 @@
           <field field_ref="toce_vmean300"   name="thetaot300"   />
 -->
           <field field_ref="soce_abs"        name="so_abs"       operation="average" freq_op="5d" > @soce_abs_e3t / @e3t </field>
-	        <field field_ref="ssh"             name="zos"          standard_name="sea_surface_height_above_geoid" long_name="Sea Surface Height Above Geoid"      />
-          <field field_ref="ssh2"            name="zossq"        standard_name="square_of_sea_surface_height_above_geoid" long_name="Square of Sea Surface Height Above Geoid"  />
-	        <field field_ref="runoffs"         name="friver"       standard_name="water_flux_into_sea_water_from_rivers"                     />
-	        <field field_ref="qt"              name="hfds"         standard_name="surface_downward_heat_flux_in_sea_water"                     />
-	        <field field_ref="qsr3d"           name="rsdo"         standard_name="downwelling_shortwave_flux_in_sea_water"                     />
-          <field field_ref="mldr0_3"         name="mlotst"       long_name="Ocean Mixed Layer Thickness Defined by Sigma T"         />
+	        <field field_ref="ssh"             name="zos"          standard_name="sea_surface_height_above_geoid" long_name="Sea Surface Height Above Geoid" />
+          <field field_ref="ssh2"            name="zossq"        standard_name="square_of_sea_surface_height_above_geoid" long_name="Square of Sea Surface Height Above Geoid" />
+	        <field field_ref="runoffs"         name="friver"       standard_name="water_flux_into_sea_water_from_rivers" />
+          <field field_ref="qt"              name="hfto"        standard_name="surface_net_downward_total_heat_flux" />
+          <field field_ref="qsr"             name="hfsr"        standard_name="surface_net_downward_solar_heat_flux" />
+          <field field_ref="qns"             name="hfns"        standard_name="surface_net_downward_non_solar_heat_flux" />
+          <field field_ref="qsr3d"           name="rsdo"        standard_name="downwelling_shortwave_flux_in_sea_water" />
+
+          <field field_ref="qt_oce"          name="hfds"    standard_name="ocean_surface_downward_total_heat_flux" />
+          <field field_ref="qlw_oce"         name="rlntds"  standard_name="ocean_surface_net_downward_longwave_heat_flux" />
+          <field field_ref="qsb_oce"         name='hfss'    standard_name="ocean_surface_downward_sensible_heat_flux" />
+          <field field_ref="qla_oce"         name="hfls"    standard_name="ocean_surface_downward_latent_heat_flux" />
+          <field field_ref="qemp_oce"        name="hfempds" standard_name="ocean_surface_downward_heat_flux_from_E-P" />
+          <field field_ref="qsr_oce"         name="rsntds"  standard_name="ocean_surface_net_downward_shortwave_heat_flux" />
+
+          <field field_ref="mldr0_3"         name="mlotst"       long_name="Ocean Mixed Layer Thickness Defined by Sigma T" />
           <field field_ref="mldr0_3"         name="mlotstsq"     long_name="Square of Ocean Mixed Layer Thickness Defined by Sigma T"  standard_name="square_of_ocean_mixed_layer_thickness_defined_by_sigma_theta" > mldr0_3 * mldr0_3 </field>
-          <field field_ref="mldr0_3"         name="mlotstmax"    long_name="Ocean Mixed Layer Thickness Defined by Sigma T" operation="maximum"        />
-          <field field_ref="mldr0_3"         name="mlotstmin"    long_name="Ocean Mixed Layer Thickness Defined by Sigma T" operation="minimum"        />
-          <field field_ref="berg_melt"       name="ficeberg"     standard_name="water_flux_into_sea_water_from_icebergs"      />
-          <field field_ref="berg_melt_qlat"  name="berg_latent_heat_flux"     standard_name="latent_heat_flux_from_icebergs"                                 />
-          <field field_ref="botpres"         name="pbo"                                                                                />
-          <field field_ref="sst_con"         name="tos_con"      standard_name="sea_surface_temperature"                                 />
-          <field field_ref="sst2_con"        name="tossq_con"   />
-          <field field_ref="sss_abs"         name="sos_abs"      standard_name="sea_surface_salinity"                                    />
+          <field field_ref="mldr0_3"         name="mlotstmax"    long_name="Ocean Mixed Layer Thickness Defined by Sigma T" operation="maximum" />
+          <field field_ref="mldr0_3"         name="mlotstmin"    long_name="Ocean Mixed Layer Thickness Defined by Sigma T" operation="minimum" />
+          <field field_ref="berg_melt"       name="ficeberg"     standard_name="water_flux_into_sea_water_from_icebergs" />
+          <field field_ref="berg_melt_qlat"  name="berg_latent_heat_flux"     standard_name="latent_heat_flux_from_icebergs" />
+          <field field_ref="botpres"         name="pbo" />
+          <field field_ref="sst_con"         name="tos_con"      standard_name="sea_surface_temperature" />
+          <field field_ref="sst2_con"        name="tossq_con" />
+          <field field_ref="sss_abs"         name="sos_abs"      standard_name="sea_surface_salinity" />
           <field field_ref="sss2_abs"        name="sossq_abs"   long_name="Square of Sea Surface Salinity"   standard_name="square_of_sea_surface_Salinity" />
 <!-- TO FIX
           <field field_ref="rain_ao_cea" name="pr" standard_name="rainfall_flux" long_name="Rainfall Flux" > @rain_ao_cea </field>
@@ -48,7 +58,7 @@
           <field field_ref="hflx_evap_cea"   name="hfevapds" long_name="Temperature Flux due to Evaporation Expressed as Heat Flux Out of Sea Water" standard_name="temperature_flux_due_to_evaporation_expressed_as_heat_flux_out_of_sea_water" />
           <field field_ref="hflx_rnf_cea"    name="hflx_rnf" long_name="Temperature Flux due to Runoff Expressed as Heat Flux into  Sea Water" standard_name="temperature_flux_due_to_runoff_expressed_as_heat_flux_into_sea_water" > hflx_rnf_cea </field> 
           <field field_ref="saltflx"         name="sfdsi" standard_name="downward_sea_ice_basal_salt_flux" />
-          <field field_ref="fmmflx"          name="fsitherm"      unit="kg/m2/s"   />
+          <field field_ref="fmmflx"          name="fsitherm"      unit="kg/m2/s" />
           <field field_ref="empmr" > @empmr + @fwfisf </field>
 <!-- TO FIX
           <field field_ref="Age" name="agessc" />
@@ -56,19 +66,19 @@
           <field field_ref="tnpeo" />
           <field field_ref="snowpre"         name="snowpre" />
           <field field_ref="snow_ai_cea"     name="snow_ai_cea" />
-	        <field field_ref="empmr"           name="sowaflup"   standard_name="water_flux_out_of_sea_ice_and_sea_water"                 />
-	        <field field_ref="saltflx"         name="sosafldo"   standard_name="salt_flux_into_sea_water"                                />
-          <field field_ref="mldkz5"          name="somixhgt"   standard_name="ocean_mixed_layer_thickness_defined_by_vertical_tracer_diffusivity"   />
-          <field field_ref="mldr10_1"        name="somxl010"   standard_name="ocean_mixed_layer_thickness_defined_by_sigma_theta"      />
-          <field field_ref="mldzint_1"       name="somxzint1"  standard_name="ocean_mixed_layer_thickness_defined_by_sigma_theta"      />
-          <field field_ref="ice_cover"       name="soicecov"   standard_name="sea_ice_area_fraction"                                   />
-          <field field_ref="wspd"            name="sowindsp"   standard_name="wind_speed"                                              />          
-          <field field_ref="qlatisf"         name="sohflisf"   standard_name=""                                                        />
-          <field field_ref="qlatisf3d_par"   name="vohflisf"   standard_name=""                                                        />
-          <field field_ref="qhcisf"          name="sohfcisf"   standard_name=""                                                        />
-          <field field_ref="qhcisf3d_par"    name="vohfcisf"   standard_name=""                                                        />
-          <field field_ref="fwfisf"          name="sowflisf"   standard_name=""                                                        />
-          <field field_ref="fwfisf3d_par"    name="vowflisf"   standard_name=""                                                        />
+	        <field field_ref="empmr"           name="sowaflup"   standard_name="water_flux_out_of_sea_ice_and_sea_water" />
+	        <field field_ref="saltflx"         name="sosafldo"   standard_name="salt_flux_into_sea_water" />
+          <field field_ref="mldkz5"          name="somixhgt"   standard_name="ocean_mixed_layer_thickness_defined_by_vertical_tracer_diffusivity" />
+          <field field_ref="mldr10_1"        name="somxl010"   standard_name="ocean_mixed_layer_thickness_defined_by_sigma_theta" />
+          <field field_ref="mldzint_1"       name="somxzint1"  standard_name="ocean_mixed_layer_thickness_defined_by_sigma_theta" />
+          <field field_ref="ice_cover"       name="soicecov"   standard_name="sea_ice_area_fraction" />
+          <field field_ref="wspd"            name="sowindsp"   standard_name="wind_speed" />          
+          <field field_ref="qlatisf"         name="sohflisf"   standard_name="" />
+          <field field_ref="qlatisf3d_par"   name="vohflisf"   standard_name="" />
+          <field field_ref="qhcisf"          name="sohfcisf"   standard_name="" />
+          <field field_ref="qhcisf3d_par"    name="vohfcisf"   standard_name="" />
+          <field field_ref="fwfisf"          name="sowflisf"   standard_name="" />
+          <field field_ref="fwfisf3d_par"    name="vowflisf"   standard_name="" />
 <!-- TO FIX
           <field field_ref="ketrd_ldf_vsum"     name="dispkexyfo"   standard_name="Dissipation of kinetic energy by lateral viscosity" grid_ref="vert_sum"/>
 -->
@@ -82,7 +92,8 @@
 -->
           <field field_ref="sbt_con"         name="sbt_con" />
           <field field_ref="sbs_abs"         name="sbs_abs" />
-<!-- trend diagnostics-->
+
+<!-- trend diagnostics
           <field field_ref="ttrd_totad_li"   name="ocontempadvect"  unit="W/m2"    />
           <field field_ref="ttrd_iso_li"     name="ocontemppmdiff"  unit="W/m2"    />
           <field field_ref="ttrd_zdfp_li"    name="ocontempdiff"    unit="W/m2"    />
@@ -100,6 +111,7 @@
           <field field_ref="strd_bbl_li"     name="strd_bbl_li"                    />
           <field field_ref="strd_atf_li"     name="strd_atf_li"                    />
 	</file>
+  -->
 	
 	<file id="file5" mode="write" writer="u5dwriter" gatherer="ugatherer" using_server2="true" name_suffix="_grid_U" description="ocean U grid variables" >
           <field field_ref="e3u"             name="e3u"     standard_name="cell_thickness" />
@@ -114,10 +126,7 @@
           <!-- available with key_diaar5 -->
           <field field_ref="u_masstr"        name="umo" /> 
           <field field_ref="u_masstr_vint"   name="umo_vint" /> 
-          <field field_ref="u_heattr"        name="hfx" > @uadv_heattr + @udiff_heattr </field> 
-          <field field_ref="uadv_heattr"     name="hfx_adv" /> 
-          <field field_ref="udiff_heattr"    name="hfx_diff" /> 
-<!--below here not in CMOR format yet -->
+          <!--below here not in CMOR format yet -->
           <field field_ref="u_salttr"        name="sozosatr" />
 	</file>
 	
@@ -133,22 +142,14 @@
           <field field_ref="voce"            name="v2o" standard_name="square_of_sea_water_y_velocity" long_name="VV"  operation="average" freq_op="5d" > @voce2_e3v / @e3v </field>
           <!-- available with key_diaar5 -->
           <field field_ref="v_masstr"        name="vmo" /> 
-          <field field_ref="v_heattr"        name="hfy" > @vadv_heattr + @vdiff_heattr </field>
-          <field field_ref="vadv_heattr"     name="hfy_adv" /> 
-          <field field_ref="vdiff_heattr"    name="hfy_diff" /> 
-<!--below here not in CMOR format yet -->
+          <!--below here not in CMOR format yet -->
           <field field_ref="v_salttr"        name="somesatr" />
 	</file>
 	
 	<file id="file7" mode="write" writer="w5dwriter" gatherer="tgatherer" using_server2="true" name_suffix="_grid_W" description="ocean W grid variables" >
           <field field_ref="e3w"             name="e3w"      standard_name="cell_thickness" />
-	        <field field_ref="avt"             name="difvho"   standard_name="ocean_vertical_heat_diffusivity"  />
-	        <field field_ref="avs"             name="difvso"   standard_name="ocean_vertical_salt_diffusivity"   />                 
-          <field field_ref="avm"             name="difvmo"   standard_name="ocean_vertical_momentum_diffusivity"               />
-          <field field_ref="avt_evd"         name="avt_evd"  standard_name="enhanced_vertical_heat_diffusivity"               />
-          <field field_ref="av_tmx"          name="diftrto"  standard_name="ocean_vertical_tracer_diffusivity_due_to_tides"               />
           <field field_ref="w_masstr"        name="wmo" />
-	        <field field_ref="woce"            name="wo"       standard_name="upward_sea_water_velocity" long_name="W"                  />
+	        <field field_ref="woce"            name="wo"       standard_name="upward_sea_water_velocity" long_name="W" />
           <field field_ref="woce"            name="w2o"      standard_name="square_of_upward_sea_water_velocity" long_name="WW"  operation="average" > woce * woce </field>
           <field field_ref="bn2"             name="obvfsq" />
 <!-- TO FIX
@@ -159,9 +160,9 @@
 	</file>
 	
         <file id="file8" mode="write" writer="s5dwriter" gatherer="tgatherer" using_server2="true" compression_level="0" name_suffix="_scalar" description="scalar variables" enabled=".true." >
-          <field field_ref="voltot"          name="scvoltot"   />
-          <field field_ref="temptot"         name="thetaoga"   />
-          <field field_ref="saltot"          name="soga"   />
+          <field field_ref="voltot"          name="scvoltot" />
+          <field field_ref="temptot"         name="thetaoga" />
+          <field field_ref="saltot"          name="soga" />
         </file>
 
       </file_group>


### PR DESCRIPTION
- [x] Removed tracer trend diagnostics from 5-day outputs.
- [x] Removed vertical diffusivity diagnostics from 5-day outputs.
- [x] Removed zonal and meridional total, advective and diffusive heat flux components from 5-day outputs.
- [x] Added surface heat flux (solar, non-solar) and components to 5-day, 1-month, 1-year outputs.
- [x] Added tracer trend diagnostics flag = .true. in namelist_cfg