### PR TITLE
54 add run scripts to transfer outputs to jasmin os

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,24 @@
-# NOC Near-Present-Day simulation
+<br />
+<p align="center">
+    <img src="./docs/docs/assets/icons/noc_logo.png" alt="Logo" width="240" height="80">
+  </a>
 
-Global configurations at eORCA12 and eORCA025
+
+  <h1 align="center">Near-Present-Day Simulations</h1>
+
+  <p align="center">
+    Global ocean model configurations (eORCA1, eORCA025 & eORCA12) to perform multi-decadal Near-Present-Day simulations.
+    </a>
+    <br />
+    <br />
+    ·
+    <a href="https://noc-msm.github.io/NOC_Near_Present_Day/"><strong>Read the Docs</strong></a>
+    ·
+    <a href="https://github.com/NOC-MSM/NOC_Near_Present_Day/issues"><strong>Report an Issue</strong></a>
+    ·
+  </p>
+</p>
+
 
 ## Quick start on {Archer2|Anemone}
 
@@ -8,7 +26,9 @@ The following commands will check out and set up an instance of NPD. It is not a
 
 ```shell
 git clone git@github.com:NOC-MSM/NOC_Near_Present_Day.git
+
 cd NOC_Near_Present_Day
+
 ./setup {-s Archer2}
 ```
 The setup script downloads nemo, compiles tools and configurations. Setup defaults to Anemone, which is ideally suited for fast development/turnaround of smaller configurations (e.g. eORCA025). 
@@ -84,23 +104,24 @@ Finally:
 sbatch run_nemo11168_48X.slurm
 ```
 
-## Using Cylc workflow [Under development]
+## Using Cylc Workflow [Under development]
 
-NPD can be run using Cylc, which provides the ability to graph the workflow, automating the resubmission of job increments, post-processing, data transfer, etc. It is currently being set up and tested on Anemone. The NEMO_cylc workflow is accessible here:
+NPD can be run using Cylc, which provides the ability to graph the workflow, automating the resubmission of job increments, post-processing, data transfer, etc. It is currently being set up and tested on Anemone. The NEMO_cylc workflow is accessible [here](https://github.com/NOC-OI/NEMO_cylc).
 
-https://github.com/NOC-OI/NEMO_cylc
-
-
-
-
-
-## Setups
-### Global eORCA12
+## Current Configurations
+### Global eORCA1
 Resolution:
-- Horizontal: 1/12°
+- Horizontal: 1°
 - Vertical: 75 levels
 
 ### Global eORCA025
 Resolution:
 - Horizontal: 1/4°
 - Vertical: 75 levels
+
+### Global eORCA12
+Resolution:
+- Horizontal: 1/2°
+- Vertical: 75 levels
+
+For more information see the [Near-Present-Day Documentation](https://noc-msm.github.io/NOC_Near_Present_Day/).

--- a/jasmin_os/eORCA025/1m/run_send_eORCA025_1m_grid_T_to_jasmin_os.slurm
+++ b/jasmin_os/eORCA025/1m/run_send_eORCA025_1m_grid_T_to_jasmin_os.slurm
@@ -1,0 +1,47 @@
+#!/bin/bash
+#SBATCH --job-name=xfer_T_eORCA025
+#SBATCH --partition=compute
+#SBATCH --time=10:00:00
+#SBATCH --ntasks-per-core=1
+#SBATCH --ntasks-per-node=64
+#SBATCH --ntasks-per-socket=32
+#SBATCH --nodes=1
+
+# ==============================================================
+# run_send_eORCA025_1m_grid_T_to_jasmin_os.slurm
+#
+# Description: SLURM script to send the eORCA025 monthly mean 
+# T-point variables to the JASMIN object store.
+#
+# Created By: Ollie Tooth (oliver.tooth@noc.ac.uk)
+# Created On: 2025-01-02
+#
+# ==============================================================
+# -- Input arguments to msm-os -- #
+# Filepath to eORCA025 ancillary file:
+filepath_grid=/dssgfs01/scratch/otooth/npd_data/simulations/Domains/eORCA025/domain_cfg.nc
+
+# Filepath to eORCA025 monthly mean output files:
+filedir=/dssgfs01/scratch/otooth/npd_data/simulations/eORCA025_JRA55/exp_npd_v1
+filepath_gridT=$filedir/eORCA025_1m_grid_T_*.nc
+
+# Filepath to JASMIN OS credentials:
+store_credentials_json=.../credentials/jasmin_os_credentials.json
+
+# Bucket and object prefix:
+bucket=npd-eorca025-jra55v1
+
+# -- Python Environment -- #
+# Activate miniconda environment:
+source /home/otooth/miniconda3/etc/profile.d/conda.sh
+conda activate env_jasmin_os
+
+# -- Send eORCA025 monthly mean outputs to JASMIN OS -- #
+echo "In Progress: Sending eORCA025 T1m variables to JASMIN object store..."
+msm_os send_with_dask -f $filepath_gridT -c $store_credentials_json -b $bucket -p T1m \
+                      -gf $filepath_grid -uc '{"nav_lon":"glamt", "nav_lat":"gphit"}' \
+                      -cs '{"x":720, "y":603, "deptht":25}' \
+                      -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/"}' \
+                      -dlc '{"n_workers":35,"threads_per_worker":1,"memory_limit":"2GB"}'
+
+echo "Completed: Sent eORCA025 monthly mean fields to JASMIN object store."

--- a/jasmin_os/eORCA025/1m/run_send_eORCA025_1m_grid_U_to_jasmin_os.slurm
+++ b/jasmin_os/eORCA025/1m/run_send_eORCA025_1m_grid_U_to_jasmin_os.slurm
@@ -1,0 +1,47 @@
+#!/bin/bash
+#SBATCH --job-name=xfer_U_eORCA025
+#SBATCH --partition=compute
+#SBATCH --time=06:00:00
+#SBATCH --ntasks-per-core=1
+#SBATCH --ntasks-per-node=64
+#SBATCH --ntasks-per-socket=32
+#SBATCH --nodes=1
+
+# ==============================================================
+# run_send_eORCA025_1m_grid_U_to_jasmin_os.slurm
+#
+# Description: SLURM script to send the eORCA025 monthly mean 
+# U-point variables to the JASMIN object store.
+#
+# Created By: Ollie Tooth (oliver.tooth@noc.ac.uk)
+# Created On: 2025-01-02
+#
+# ==============================================================
+# -- Input arguments to msm-os -- #
+# Filepath to eORCA025 ancillary file:
+filepath_grid=/dssgfs01/scratch/otooth/npd_data/simulations/Domains/eORCA025/domain_cfg.nc
+
+# Filepath to eORCA025 monthly mean output files:
+filedir=/dssgfs01/scratch/otooth/npd_data/simulations/eORCA025_JRA55/exp_npd_v1
+filepath_gridU=$filedir/eORCA025_1m_grid_U_*.nc
+
+# Filepath to JASMIN OS credentials:
+store_credentials_json=.../credentials/jasmin_os_credentials.json
+
+# Bucket and object prefix:
+bucket=npd-eorca025-jra55v1
+
+# -- Python Environment -- #
+# Activate miniconda environment:
+source /home/otooth/miniconda3/etc/profile.d/conda.sh
+conda activate env_jasmin_os
+
+# -- Send eORCA025 monthly mean outputs to JASMIN OS -- #
+echo "In Progress: Sending eORCA025 U1m variables to JASMIN object store..."
+msm_os send_with_dask -f $filepath_gridU -c $store_credentials_json -b $bucket -p U1m \
+                      -gf $filepath_grid -uc '{"nav_lon":"glamu", "nav_lat":"gphiu"}' \
+                      -cs '{"x":720, "y":603, "depthu":25}' \
+                      -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/"}' \
+                      -dlc '{"n_workers":40,"threads_per_worker":1,"memory_limit":"2GB"}'
+
+echo "Completed: Sent eORCA025 monthly mean fields to JASMIN object store."

--- a/jasmin_os/eORCA025/1m/run_send_eORCA025_1m_grid_V_to_jasmin_os.slurm
+++ b/jasmin_os/eORCA025/1m/run_send_eORCA025_1m_grid_V_to_jasmin_os.slurm
@@ -1,0 +1,47 @@
+#!/bin/bash
+#SBATCH --job-name=xfer_V_eORCA025
+#SBATCH --partition=compute
+#SBATCH --time=06:00:00
+#SBATCH --ntasks-per-core=1
+#SBATCH --ntasks-per-node=64
+#SBATCH --ntasks-per-socket=32
+#SBATCH --nodes=1
+
+# ==============================================================
+# run_send_eORCA025_1m_grid_V_to_jasmin_os.slurm
+#
+# Description: SLURM script to send the eORCA025 monthly mean 
+# V-point variables to the JASMIN object store.
+#
+# Created By: Ollie Tooth (oliver.tooth@noc.ac.uk)
+# Created On: 2025-01-02
+#
+# ==============================================================
+# -- Input arguments to msm-os -- #
+# Filepath to eORCA025 ancillary file:
+filepath_grid=/dssgfs01/scratch/otooth/npd_data/simulations/Domains/eORCA025/domain_cfg.nc
+
+# Filepath to eORCA025 monthly mean output files:
+filedir=/dssgfs01/scratch/otooth/npd_data/simulations/eORCA025_JRA55/exp_npd_v1
+filepath_gridV=$filedir/eORCA025_1m_grid_V_*.nc
+
+# Filepath to JASMIN OS credentials:
+store_credentials_json=.../credentials/jasmin_os_credentials.json
+
+# Bucket and object prefix:
+bucket=npd-eorca025-jra55v1
+
+# -- Python Environment -- #
+# Activate miniconda environment:
+source /home/otooth/miniconda3/etc/profile.d/conda.sh
+conda activate env_jasmin_os
+
+# -- Send eORCA025 monthly mean outputs to JASMIN OS -- #
+echo "In Progress: Sending eORCA025 V1m variables to JASMIN object store..."
+msm_os send_with_dask -f $filepath_gridV -c $store_credentials_json -b $bucket -p V1m \
+                      -gf $filepath_grid -uc '{"nav_lon":"glamv", "nav_lat":"gphiv"}' \
+                      -cs '{"x":720, "y":603, "depthv":25}' \
+                      -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/"}' \
+                      -dlc '{"n_workers":40,"threads_per_worker":1,"memory_limit":"2GB"}'
+
+echo "Completed: Sent eORCA025 monthly mean fields to JASMIN object store."

--- a/jasmin_os/eORCA025/1m/run_send_eORCA025_1m_grid_W_to_jasmin_os.slurm
+++ b/jasmin_os/eORCA025/1m/run_send_eORCA025_1m_grid_W_to_jasmin_os.slurm
@@ -1,0 +1,47 @@
+#!/bin/bash
+#SBATCH --job-name=xfer_W_eORCA025
+#SBATCH --partition=compute
+#SBATCH --time=08:00:00
+#SBATCH --ntasks-per-core=1
+#SBATCH --ntasks-per-node=64
+#SBATCH --ntasks-per-socket=32
+#SBATCH --nodes=1
+
+# ==============================================================
+# run_send_eORCA025_1m_grid_W_to_jasmin_os.slurm
+#
+# Description: SLURM script to send the eORCA025 monthly mean 
+# W-point variables to the JASMIN object store.
+#
+# Created By: Ollie Tooth (oliver.tooth@noc.ac.uk)
+# Created On: 2025-01-02
+#
+# ==============================================================
+# -- Input arguments to msm-os -- #
+# Filepath to eORCA025 ancillary file:
+filepath_grid=/dssgfs01/scratch/otooth/npd_data/simulations/Domains/eORCA025/domain_cfg.nc
+
+# Filepath to eORCA025 monthly mean output files:
+filedir=/dssgfs01/scratch/otooth/npd_data/simulations/eORCA025_JRA55/exp_npd_v1
+filepath_gridW=$filedir/eORCA025_1m_grid_W_*.nc
+
+# Filepath to JASMIN OS credentials:
+store_credentials_json=.../credentials/jasmin_os_credentials.json
+
+# Bucket and object prefix:
+bucket=npd-eorca025-jra55v1
+
+# -- Python Environment -- #
+# Activate miniconda environment:
+source /home/otooth/miniconda3/etc/profile.d/conda.sh
+conda activate env_jasmin_os
+
+# -- Send eORCA025 monthly mean outputs to JASMIN OS -- #
+echo "In Progress: Sending eORCA025 W1m variables to JASMIN object store..."
+msm_os send_with_dask -f $filepath_gridW -c $store_credentials_json -b $bucket -p W1m \
+                      -gf $filepath_grid -uc '{"nav_lon":"glamt", "nav_lat":"gphit"}' \
+                      -cs '{"x":720, "y":603, "depthw":25}' \
+                      -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/"}' \
+                      -dlc '{"n_workers":40,"threads_per_worker":1,"memory_limit":"2GB"}'
+
+echo "Completed: Sent eORCA025 monthly mean fields to JASMIN object store."

--- a/jasmin_os/eORCA025/1m/run_send_eORCA025_1m_icemod_to_jasmin_os.slurm
+++ b/jasmin_os/eORCA025/1m/run_send_eORCA025_1m_icemod_to_jasmin_os.slurm
@@ -1,0 +1,47 @@
+#!/bin/bash
+#SBATCH --job-name=xfer_I_eORCA025
+#SBATCH --partition=compute
+#SBATCH --time=04:00:00
+#SBATCH --ntasks-per-core=1
+#SBATCH --ntasks-per-node=64
+#SBATCH --ntasks-per-socket=32
+#SBATCH --nodes=1
+
+# ==============================================================
+# run_send_eORCA025_1m_icemod_to_jasmin_os.slurm
+#
+# Description: SLURM script to send the eORCA025 monthly mean 
+# SI3 ice model variables to the JASMIN object store.
+#
+# Created By: Ollie Tooth (oliver.tooth@noc.ac.uk)
+# Created On: 2025-01-02
+#
+# ==============================================================
+# -- Input arguments to msm-os -- #
+# Filepath to eORCA025 ancillary file:
+filepath_grid=/dssgfs01/scratch/otooth/npd_data/simulations/Domains/eORCA025/domain_cfg.nc
+
+# Filepath to eORCA025 monthly mean output files:
+filedir=/dssgfs01/scratch/otooth/npd_data/simulations/eORCA025_JRA55/exp_npd_v1
+filepath_icemod=$filedir/eORCA025_1m_icemod_*.nc
+
+# Filepath to JASMIN OS credentials:
+store_credentials_json=.../credentials/jasmin_os_credentials.json
+
+# Bucket and object prefix:
+bucket=npd-eorca025-jra55v1
+
+# -- Python Environment -- #
+# Activate miniconda environment:
+source /home/otooth/miniconda3/etc/profile.d/conda.sh
+conda activate env_jasmin_os
+
+# -- Send eORCA025 monthly mean outputs to JASMIN OS -- #
+echo "In Progress: Sending eORCA025 I1m variables to JASMIN object store..."
+msm_os send_with_dask -f $filepath_icemod -c $store_credentials_json -b $bucket -p I1m \
+                      -gf $filepath_grid -uc '{"nav_lon":"glamt", "nav_lat":"gphit"}' \
+                      -cs '{"x":720, "y":603}' \
+                      -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/"}' \
+                      -dlc '{"n_workers":30,"threads_per_worker":1,"memory_limit":"2GB"}'
+
+echo "Completed: Sent eORCA025 monthly mean fields to JASMIN object store."

--- a/jasmin_os/eORCA025/1m/run_send_eORCA025_1m_scalar_to_jasmin_os.slurm
+++ b/jasmin_os/eORCA025/1m/run_send_eORCA025_1m_scalar_to_jasmin_os.slurm
@@ -1,0 +1,47 @@
+#!/bin/bash
+#SBATCH --job-name=xfer_scalar_eORCA025
+#SBATCH --partition=compute
+#SBATCH --time=03:00:00
+#SBATCH --ntasks-per-core=1
+#SBATCH --ntasks-per-node=64
+#SBATCH --ntasks-per-socket=32
+#SBATCH --nodes=1
+
+# ==============================================================
+# run_send_eORCA025_1m_scalar_to_jasmin_os.slurm
+#
+# Description: SLURM script to send the eORCA025 monthly mean 
+# scalar variables to the JASMIN object store.
+#
+# Created By: Ollie Tooth (oliver.tooth@noc.ac.uk)
+# Created On: 2025-01-02
+#
+# ==============================================================
+# -- Input arguments to msm-os -- #
+# Filepath to eORCA025 ancillary file:
+filepath_grid=/dssgfs01/scratch/otooth/npd_data/simulations/Domains/eORCA025/domain_cfg.nc
+
+# Filepath to eORCA025 monthly mean output files:
+filedir=/dssgfs01/scratch/otooth/npd_data/simulations/eORCA025_JRA55/exp_npd_v1
+filepath_scalar=$filedir/eORCA025_1m_scalar_*.nc
+
+# Filepath to JASMIN OS credentials:
+store_credentials_json=.../credentials/jasmin_os_credentials.json
+
+# Bucket and object prefix:
+bucket=npd-eorca025-jra55v1
+
+# -- Python Environment -- #
+# Activate miniconda environment:
+source /home/otooth/miniconda3/etc/profile.d/conda.sh
+conda activate env_jasmin_os
+
+# -- Send eORCA025 files to JASMIN OS -- #
+echo "In Progress: Sending eORCA025 scalar variables to JASMIN object store..."
+msm_os send_with_dask -f $filepath_scalar -c $store_credentials_json -b $bucket -p S1m \
+                      -gf $filepath_grid -uc '{"nav_lon":"glamt", "nav_lat":"gphit"}' \
+                      -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/"}' \
+                      -dlc '{"n_workers":10,"threads_per_worker":1,"memory_limit":"2GB"}'
+
+echo "Completed: Sent eORCA025 monthly mean fields to JASMIN object store."
+

--- a/jasmin_os/eORCA025/1y/run_send_eORCA025_1y_to_jasmin_os.slurm
+++ b/jasmin_os/eORCA025/1y/run_send_eORCA025_1y_to_jasmin_os.slurm
@@ -1,0 +1,86 @@
+#!/bin/bash
+#SBATCH --job-name=xfer_1y_eORCA025
+#SBATCH --partition=compute
+#SBATCH --time=05:00:00
+#SBATCH --ntasks-per-core=1
+#SBATCH --ntasks-per-node=64
+#SBATCH --ntasks-per-socket=32
+#SBATCH --nodes=1
+
+# ==============================================================
+# run_send_eORCA025_1y_to_jasmin_os.slurm
+#
+# Description: SLURM script to send the eORCA025 monthly-mean 
+# output variables to the JASMIN object store.
+#
+# Created By: Ollie Tooth (oliver.tooth@noc.ac.uk)
+# Created On: 2025-01-02
+#
+# ==============================================================
+# -- Input arguments to msm-os -- #
+# Filepath to eORCA025 ancillary file:
+filepath_grid=/dssgfs01/scratch/otooth/npd_data/simulations/Domains/eORCA025/domain_cfg.nc
+
+# Filepath to eORCA025 annual mean output files:
+filedir=/dssgfs01/scratch/otooth/npd_data/simulations/eORCA025_JRA55/exp_npd_v1
+filepath_gridT=$filedir/eORCA025_1y_grid_T_*.nc
+filepath_gridU=$filedir/eORCA025_1y_grid_U_*.nc
+filepath_gridV=$filedir/eORCA025_1y_grid_V_*.nc
+filepath_gridW=$filedir/eORCA025_1y_grid_W_*.nc
+filepath_icemod=$filedir/eORCA025_1y_icemod_*.nc
+filepath_scalar=$filedir/eORCA025_1y_scalar_*.nc
+
+# Filepath to JASMIN OS credentials:
+store_credentials_json=/dssgfs01/working/otooth/AtlantiS/jasmin_os/credentials/jasmin_os_credentials.json
+
+# Bucket and object prefix:
+bucket=npd-eorca025-jra55v1
+
+# -- Python Environment -- #
+# Activate miniconda environment:
+source /home/otooth/miniconda3/etc/profile.d/conda.sh
+conda activate env_jasmin_os
+
+# -- Send eORCA025 annual mean outputs to JASMIN OS -- #
+echo "In Progress: Sending eORCA025 T1y variables to JASMIN object store..."
+msm_os send_with_dask -f $filepath_gridT -c $store_credentials_json -b $bucket -p T1y \
+                      -gf $filepath_grid -uc '{"nav_lon":"glamt", "nav_lat":"gphit"}' \
+                      -cs '{"x":720, "y":603, "deptht":25}' \
+                      -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/"}' \
+                      -dlc '{"n_workers":30,"threads_per_worker":1,"memory_limit":"2GB"}'
+
+echo "In Progress: Sending eORCA025 U1y variables to JASMIN object store..."
+msm_os send_with_dask -f $filepath_gridU -c $store_credentials_json -b $bucket -p U1y \
+                      -gf $filepath_grid -uc '{"nav_lon":"glamu", "nav_lat":"gphiu"}' \
+                      -cs '{"x":720, "y":603, "depthu":25}' \
+                      -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/"}' \
+                      -dlc '{"n_workers":30,"threads_per_worker":1,"memory_limit":"2GB"}'
+
+echo "In Progress: Sending eORCA025 V1y variables to JASMIN object store..."
+msm_os send_with_dask -f $filepath_gridV -c $store_credentials_json -b $bucket -p V1y \
+                      -gf $filepath_grid -uc '{"nav_lon":"glamv", "nav_lat":"gphiv"}' \
+                      -cs '{"x":720, "y":603, "depthv":25}' \
+                      -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/"}' \
+                      -dlc '{"n_workers":30,"threads_per_worker":1,"memory_limit":"2GB"}'
+
+echo "In Progress: Sending eORCA025 W1y variables to JASMIN object store..."
+msm_os send_with_dask -f $filepath_gridW -c $store_credentials_json -b $bucket -p W1y \
+                      -gf $filepath_grid -uc '{"nav_lon":"glamt", "nav_lat":"gphit"}' \
+                      -cs '{"x":720, "y":603, "depthw":25}' \
+                      -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/"}' \
+                      -dlc '{"n_workers":30,"threads_per_worker":1,"memory_limit":"2GB"}'
+
+echo "In Progress: Sending eORCA025 I1y variables to JASMIN object store..."
+msm_os send_with_dask -f $filepath_icemod -c $store_credentials_json -b $bucket -p I1y \
+                      -gf $filepath_grid -uc '{"nav_lon":"glamt", "nav_lat":"gphit"}' \
+                      -cs '{"x":720, "y":603}' \
+                      -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/"}' \
+                      -dlc '{"n_workers":30,"threads_per_worker":1,"memory_limit":"2GB"}'
+
+echo "In Progress: Sending eORCA025 S1y variables to JASMIN object store..."
+msm_os send_with_dask -f $filepath_scalar -c $store_credentials_json -b $bucket -p S1y \
+                      -gf $filepath_grid -uc '{"nav_lon":"glamt", "nav_lat":"gphit"}' \
+                      -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/"}' \
+                      -dlc '{"n_workers":5,"threads_per_worker":1,"memory_limit":"2GB"}'
+
+echo "Completed: Sent eORCA025 annual mean fields to JASMIN object store."

--- a/jasmin_os/eORCA025/5d/run_send_eORCA025_5d_grid_T_to_jasmin_os.slurm
+++ b/jasmin_os/eORCA025/5d/run_send_eORCA025_5d_grid_T_to_jasmin_os.slurm
@@ -1,0 +1,54 @@
+#!/bin/bash
+#SBATCH --job-name=xfer_T5d_eORCA025
+#SBATCH --partition=compute
+#SBATCH --time=12:00:00
+#SBATCH --ntasks-per-core=1
+#SBATCH --ntasks-per-node=64
+#SBATCH --ntasks-per-socket=32
+#SBATCH --nodes=1
+
+# ==============================================================
+# run_send_eORCA025_5d_grid_T_to_jasmin_os.slurm
+#
+# Description: SLURM script to send the eORCA025 5-day mean 
+# T-point variables to the JASMIN object store.
+#
+# Created By: Ollie Tooth (oliver.tooth@noc.ac.uk)
+# Created On: 2025-01-02
+#
+# ==============================================================
+# -- Input arguments to msm-os -- #
+# Filepath to eORCA025 ancillary file:
+filepath_grid=/dssgfs01/scratch/otooth/npd_data/simulations/Domains/eORCA025/domain_cfg.nc
+
+# Filepath to eORCA025 5-day mean mean output files:
+filedir=/dssgfs01/scratch/otooth/npd_data/simulations/eORCA025_JRA55/exp_npd_v1
+
+# Filepath to JASMIN OS credentials:
+store_credentials_json=.../credentials/jasmin_os_credentials.json
+
+# Bucket and object prefix:
+bucket=npd-eorca025-jra55v1
+
+# -- Python Environment -- #
+# Activate miniconda environment:
+source /home/otooth/miniconda3/etc/profile.d/conda.sh
+conda activate env_jasmin_os
+
+# -- Send eORCA025 5-day mean outputs to JASMIN OS -- #
+for yr in {1976..2024}
+do
+    # Define the filepath to the 5-day mean T-point files:
+    filepath_gridT=$filedir/eORCA025_5d_grid_T_${yr}*.nc
+    # Define the object prefix for the JASMIN object store:
+    object_prefix=T5d/${yr}
+
+    echo "In Progress: Sending $yr eORCA025 T5d variables to JASMIN object store..."
+    msm_os send_with_dask -f $filepath_gridT -c $store_credentials_json -b $bucket -p $object_prefix \
+                          -gf $filepath_grid -uc '{"nav_lon":"glamt", "nav_lat":"gphit"}' \
+                          -cs '{"x":720, "y":603, "deptht":25}' \
+                          -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/gridT/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/gridT/"}' \
+                          -dlc '{"n_workers":30,"threads_per_worker":1,"memory_limit":"2.5GB"}'
+
+    echo "Completed: Sent $yr eORCA025 5-day mean fields to JASMIN object store."
+done

--- a/jasmin_os/eORCA025/5d/run_send_eORCA025_5d_grid_U_to_jasmin_os.slurm
+++ b/jasmin_os/eORCA025/5d/run_send_eORCA025_5d_grid_U_to_jasmin_os.slurm
@@ -1,0 +1,54 @@
+#!/bin/bash
+#SBATCH --job-name=xfer_U5d_eORCA025
+#SBATCH --partition=compute
+#SBATCH --time=06:00:00
+#SBATCH --ntasks-per-core=1
+#SBATCH --ntasks-per-node=64
+#SBATCH --ntasks-per-socket=32
+#SBATCH --nodes=1
+
+# ==============================================================
+# run_send_eORCA025_5d_grid_U_to_jasmin_os.slurm
+#
+# Description: SLURM script to send the eORCA025 5-day mean 
+# U-point variables to the JASMIN object store.
+#
+# Created By: Ollie Tooth (oliver.tooth@noc.ac.uk)
+# Created On: 2025-01-02
+#
+# ==============================================================
+# -- Input arguments to msm-os -- #
+# Filepath to eORCA025 ancillary file:
+filepath_grid=/dssgfs01/scratch/otooth/npd_data/simulations/Domains/eORCA025/domain_cfg.nc
+
+# Filepath to eORCA025 monthly mean output files:
+filedir=/dssgfs01/scratch/otooth/npd_data/simulations/eORCA025_JRA55/exp_npd_v1
+
+# Filepath to JASMIN OS credentials:
+store_credentials_json=.../credentials/jasmin_os_credentials.json
+
+# Bucket and object prefix:
+bucket=npd-eorca025-jra55v1
+
+# -- Python Environment -- #
+# Activate miniconda environment:
+source /home/otooth/miniconda3/etc/profile.d/conda.sh
+conda activate env_jasmin_os
+
+# -- Send eORCA025 5-day mean outputs to JASMIN OS -- #
+for yr in {1976..2024}
+do
+    # Define the filepath to the 5-day mean U-point files:
+    filepath_gridU=$filedir/eORCA025_5d_grid_U_${yr}*.nc
+    # Define the object prefix for the JASMIN object store:
+    object_prefix=U5d/${yr}
+
+    echo "In Progress: Sending $yr eORCA025 U5d variables to JASMIN object store..."
+    msm_os send_with_dask -f $filepath_gridU -c $store_credentials_json -b $bucket -p $object_prefix \
+                          -gf $filepath_grid -uc '{"nav_lon":"glamu", "nav_lat":"gphiu"}' \
+                          -cs '{"x":720, "y":603, "depthu":25}' \
+                          -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/gridU/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/gridU/"}' \
+                          -dlc '{"n_workers":35,"threads_per_worker":1,"memory_limit":"2.5GB"}'
+
+    echo "Completed: Sent $yr eORCA025 5-day mean fields to JASMIN object store."
+done

--- a/jasmin_os/eORCA025/5d/run_send_eORCA025_5d_grid_V_to_jasmin_os.slurm
+++ b/jasmin_os/eORCA025/5d/run_send_eORCA025_5d_grid_V_to_jasmin_os.slurm
@@ -1,0 +1,54 @@
+#!/bin/bash
+#SBATCH --job-name=xfer_V5d_eORCA025
+#SBATCH --partition=compute
+#SBATCH --time=10:00:00
+#SBATCH --ntasks-per-core=1
+#SBATCH --ntasks-per-node=64
+#SBATCH --ntasks-per-socket=32
+#SBATCH --nodes=1
+
+# ==============================================================
+# run_send_eORCA025_5d_grid_V_to_jasmin_os.slurm
+#
+# Description: SLURM script to send the eORCA025 5-day mean 
+# V-point variables to the JASMIN object store.
+#
+# Created By: Ollie Tooth (oliver.tooth@noc.ac.uk)
+# Created On: 2025-01-02
+#
+# ==============================================================
+# -- Input arguments to msm-os -- #
+# Filepath to eORCA025 ancillary file:
+filepath_grid=/dssgfs01/scratch/otooth/npd_data/simulations/Domains/eORCA025/domain_cfg.nc
+
+# Filepath to eORCA025 monthly mean output files:
+filedir=/dssgfs01/scratch/otooth/npd_data/simulations/eORCA025_JRA55/exp_npd_v1
+
+# Filepath to JASMIN OS credentials:
+store_credentials_json=.../credentials/jasmin_os_credentials.json
+
+# Bucket and object prefix:
+bucket=npd-eorca025-jra55v1
+
+# -- Python Environment -- #
+# Activate miniconda environment:
+source /home/otooth/miniconda3/etc/profile.d/conda.sh
+conda activate env_jasmin_os
+
+# -- Send eORCA025 5-day mean outputs to JASMIN OS -- #
+for yr in {1976..2024}
+do
+    # Define the filepath to the 5-day mean V-point files:
+    filepath_gridV=$filedir/eORCA025_5d_grid_V_${yr}*.nc
+    # Define the object prefix for the JASMIN object store:
+    object_prefix=V5d/${yr}
+
+    echo "In Progress: Sending $yr eORCA025 V5d variables to JASMIN object store..."
+    msm_os send_with_dask -f $filepath_gridV -c $store_credentials_json -b $bucket -p $object_prefix \
+                          -gf $filepath_grid -uc '{"nav_lon":"glamv", "nav_lat":"gphiv"}' \
+                          -cs '{"x":720, "y":603, "depthv":25}' \
+                          -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/gridV/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/gridV/"}' \
+                          -dlc '{"n_workers":30,"threads_per_worker":1,"memory_limit":"2.5GB"}'
+
+    echo "Completed: Sent $yr eORCA025 5-day mean fields to JASMIN object store."
+done

--- a/jasmin_os/eORCA025/5d/run_send_eORCA025_5d_grid_W_to_jasmin_os.slurm
+++ b/jasmin_os/eORCA025/5d/run_send_eORCA025_5d_grid_W_to_jasmin_os.slurm
@@ -1,0 +1,54 @@
+#!/bin/bash
+#SBATCH --job-name=xfer_W5d_eORCA025
+#SBATCH --partition=compute
+#SBATCH --time=08:00:00
+#SBATCH --ntasks-per-core=1
+#SBATCH --ntasks-per-node=64
+#SBATCH --ntasks-per-socket=32
+#SBATCH --nodes=1
+
+# ==============================================================
+# run_send_eORCA025_5d_grid_W_to_jasmin_os.slurm
+#
+# Description: SLURM script to send the eORCA025 5-day mean 
+# W-point variables to the JASMIN object store.
+#
+# Created By: Ollie Tooth (oliver.tooth@noc.ac.uk)
+# Created On: 2025-01-02
+#
+# ==============================================================
+# -- Input arguments to msm-os -- #
+# Filepath to eORCA025 ancillary file:
+filepath_grid=/dssgfs01/scratch/otooth/npd_data/simulations/Domains/eORCA025/domain_cfg.nc
+
+# Filepath to eORCA025 monthly mean output files:
+filedir=/dssgfs01/scratch/otooth/npd_data/simulations/eORCA025_JRA55/exp_npd_v1
+
+# Filepath to JASMIN OS credentials:
+store_credentials_json=.../credentials/jasmin_os_credentials.json
+
+# Bucket and object prefix:
+bucket=npd-eorca025-jra55v1
+
+# -- Python Environment -- #
+# Activate miniconda environment:
+source /home/otooth/miniconda3/etc/profile.d/conda.sh
+conda activate env_jasmin_os
+
+# -- Send eORCA025 5-day mean outputs to JASMIN OS -- #
+for yr in {1976..2024}
+do
+    # Define the filepath to the 5-day mean W-point files:
+    filepath_gridW=$filedir/eORCA025_5d_grid_W_${yr}*.nc
+    # Define the object prefix for the JASMIN object store:
+    object_prefix=W5d/${yr}
+
+    echo "In Progress: Sending $yr eORCA025 W5d variables to JASMIN object store..."
+    msm_os send_with_dask -f $filepath_gridW -c $store_credentials_json -b $bucket -p $object_prefix \
+                          -gf $filepath_grid -uc '{"nav_lon":"glamt", "nav_lat":"gphit"}' \
+                          -cs '{"x":720, "y":603, "depthw":25}' \
+                          -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/gridW/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/gridW/"}' \
+                          -dlc '{"n_workers":30,"threads_per_worker":1,"memory_limit":"2.5GB"}'
+
+    echo "Completed: Sent $yr eORCA025 5-day mean fields to JASMIN object store."
+done

--- a/jasmin_os/eORCA025/5d/run_send_eORCA025_5d_icemod_to_jasmin_os.slurm
+++ b/jasmin_os/eORCA025/5d/run_send_eORCA025_5d_icemod_to_jasmin_os.slurm
@@ -1,0 +1,54 @@
+#!/bin/bash
+#SBATCH --job-name=xfer_I5d_eORCA025
+#SBATCH --partition=compute
+#SBATCH --time=06:00:00
+#SBATCH --ntasks-per-core=1
+#SBATCH --ntasks-per-node=64
+#SBATCH --ntasks-per-socket=32
+#SBATCH --nodes=1
+
+# ==============================================================
+# run_send_eORCA025_5d_icemod_to_jasmin_os.slurm
+#
+# Description: SLURM script to send the eORCA025 5-day mean 
+# SI3 ice model variables to the JASMIN object store.
+#
+# Created By: Ollie Tooth (oliver.tooth@noc.ac.uk)
+# Created On: 2025-01-02
+#
+# ==============================================================
+# -- Input arguments to msm-os -- #
+# Filepath to eORCA025 ancillary file:
+filepath_grid=/dssgfs01/scratch/otooth/npd_data/simulations/Domains/eORCA025/domain_cfg.nc
+
+# Filepath to eORCA025 monthly mean output files:
+filedir=/dssgfs01/scratch/otooth/npd_data/simulations/eORCA025_JRA55/exp_npd_v1
+
+# Filepath to JASMIN OS credentials:
+store_credentials_json=.../credentials/jasmin_os_credentials.json
+
+# Bucket and object prefix:
+bucket=npd-eorca025-jra55v1
+
+# -- Python Environment -- #
+# Activate miniconda environment:
+source /home/otooth/miniconda3/etc/profile.d/conda.sh
+conda activate env_jasmin_os
+
+# -- Send eORCA025 5-day mean outputs to JASMIN OS -- #
+for yr in {1976..2024}
+do
+    # Define the filepath to the 5-day mean I-point files:
+    filepath_icemod=$filedir/eORCA025_5d_icemod_${yr}*.nc
+    # Define the object prefix for the JASMIN object store:
+    object_prefix=I5d/${yr}
+
+    echo "In Progress: Sending $yr eORCA025 I5d variables to JASMIN object store..."
+    msm_os send_with_dask -f $filepath_icemod -c $store_credentials_json -b $bucket -p $object_prefix \
+                          -gf $filepath_grid -uc '{"nav_lon":"glamt", "nav_lat":"gphit"}' \
+                          -cs '{"x":720, "y":603}' \
+                          -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/icemod/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/icemod/"}' \
+                          -dlc '{"n_workers":30,"threads_per_worker":1,"memory_limit":"2.5GB"}'
+
+    echo "Completed: Sent $yr eORCA025 5-day mean fields to JASMIN object store."
+done

--- a/jasmin_os/eORCA025/5d/run_send_eORCA025_5d_scalar_to_jasmin_os.slurm
+++ b/jasmin_os/eORCA025/5d/run_send_eORCA025_5d_scalar_to_jasmin_os.slurm
@@ -1,0 +1,55 @@
+#!/bin/bash
+#SBATCH --job-name=xfer_S5d_eORCA025
+#SBATCH --partition=compute
+#SBATCH --time=05:00:00
+#SBATCH --ntasks-per-core=1
+#SBATCH --ntasks-per-node=64
+#SBATCH --ntasks-per-socket=32
+#SBATCH --nodes=1
+
+# ==============================================================
+# run_send_eORCA025_5d_scalar_to_jasmin_os.slurm
+#
+# Description: SLURM script to send the eORCA025 5-day mean 
+# scalar variables to the JASMIN object store.
+#
+# Created By: Ollie Tooth (oliver.tooth@noc.ac.uk)
+# Created On: 2025-01-02
+#
+# ==============================================================
+# -- Input arguments to msm-os -- #
+# Filepath to eORCA025 ancillary file:
+filepath_grid=/dssgfs01/scratch/otooth/npd_data/simulations/Domains/eORCA025/domain_cfg.nc
+
+# Filepath to eORCA025 monthly mean output files:
+filedir=/dssgfs01/scratch/otooth/npd_data/simulations/eORCA025_JRA55/exp_npd_v1
+
+# Filepath to JASMIN OS credentials:
+store_credentials_json=.../credentials/jasmin_os_credentials.json
+
+# Bucket and object prefix:
+bucket=npd-eorca025-jra55v1
+
+# -- Python Environment -- #
+# Activate miniconda environment:
+source /home/otooth/miniconda3/etc/profile.d/conda.sh
+conda activate env_jasmin_os
+
+# -- Send eORCA025 files to JASMIN OS -- #
+# -- Send eORCA025 5-day mean outputs to JASMIN OS -- #
+for yr in {1976..2024}
+do
+    # Define the filepath to the 5-day mean scalar files:
+    filepath_scalar=$filedir/eORCA025_5d_scalar_${yr}*.nc
+    # Define the object prefix for the JASMIN object store:
+    object_prefix=S5d/${yr}
+
+    echo "In Progress: Sending $yr eORCA025 I1m variables to JASMIN object store..."
+    msm_os send_with_dask -f $filepath_scalar -c $store_credentials_json -b $bucket -p $object_prefix \
+                          -gf $filepath_grid -uc '{"nav_lon":"glamt", "nav_lat":"gphit"}' \
+                          -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/scalar/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/scalar/"}' \
+                          -dlc '{"n_workers":30,"threads_per_worker":1,"memory_limit":"2.5GB"}'
+
+    echo "Completed: Sent $yr eORCA025 5-day mean fields to JASMIN object store."
+done
+

--- a/jasmin_os/eORCA025/diags/run_send_eORCA025_metric_to_jasmin_os.slurm
+++ b/jasmin_os/eORCA025/diags/run_send_eORCA025_metric_to_jasmin_os.slurm
@@ -1,0 +1,57 @@
+#!/bin/bash
+#SBATCH --job-name=xfer_metric_eORCA025
+#SBATCH --partition=compute
+#SBATCH --time=00:30:00
+#SBATCH --ntasks-per-core=1
+#SBATCH --ntasks-per-node=64
+#SBATCH --ntasks-per-socket=32
+#SBATCH --nodes=1
+
+# ==============================================================
+# run_send_eORCA025_metric_to_jasmin_os.slurm
+#
+# Description: SLURM script to send the eORCA025 METRIC section 
+# variables for the RAPID, MOVE and SAMBA arrays to the JASMIN
+# object store.
+#
+# Created By: Ollie Tooth (oliver.tooth@noc.ac.uk)
+# Created On: 2025-01-02
+#
+# ==============================================================
+# -- Input arguments to msm-os -- #
+# Filepath to eORCA025 ancillary file:
+filepath_rapid=/dssgfs01/scratch/otooth/npd_data/simulations/eORCA025_JRA55/metric_npd_v1/eORCA025_1976-01-2024-01_natl_meridional_transports_at_26N.nc
+filepath_move=/dssgfs01/scratch/otooth/npd_data/simulations/eORCA025_JRA55/metric_npd_v1/eORCA025_1976-01-2024-01_natl_meridional_transports_at_16N.nc
+filepath_samba=/dssgfs01/scratch/otooth/npd_data/simulations/eORCA025_JRA55/metric_npd_v1/eORCA025_1976-01-2024-01_natl_meridional_transports_at_34_5S.nc
+
+# Filepath to JASMIN OS credentials:
+store_credentials_json=.../credentials/jasmin_os_credentials.json
+
+# Bucket and object prefix:
+bucket=npd-eorca025-jra55v1
+
+# Variables - save entire dataset to single zarr store - and chunks:
+variables=compact
+
+# -- Python Environment -- #
+# Activate miniconda environment:
+source /home/otooth/miniconda3/etc/profile.d/conda.sh
+conda activate env_jasmin_os
+
+# -- Send METRIC eORCA025 monthly mean output to JASMIN OS -- #
+echo "In Progress: Sending eORCA025 monthly METRIC RAPID 26.5N outputs to JASMIN object store..."
+msm_os send_with_dask -f $filepath_rapid -c $store_credentials_json -b $bucket -p M1m/rapid_26N -v $variables \
+                      -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/"}' \
+                      -dlc '{"n_workers":10,"threads_per_worker":4,"memory_limit":"3GB"}'
+
+echo "In Progress: Sending eORCA025 monthly METRIC MOVE 16N outputs to JASMIN object store..."
+msm_os send_with_dask -f $filepath_move -c $store_credentials_json -b $bucket -p M1m/move_16N -v $variables \
+                      -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/"}' \
+                      -dlc '{"n_workers":10,"threads_per_worker":4,"memory_limit":"3GB"}'
+
+echo "In Progress: Sending eORCA025 monthly METRIC SAMBA 34.5S outputs to JASMIN object store..."
+msm_os send_with_dask -f $filepath_samba -c $store_credentials_json -b $bucket -p M1m/samba_34_5S -v $variables \
+                      -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/"}' \
+                      -dlc '{"n_workers":10,"threads_per_worker":4,"memory_limit":"3GB"}'
+
+echo "Completed: Sent eORCA025 monthly METRIC outputs to JASMIN object store."

--- a/jasmin_os/eORCA025/diags/run_send_eORCA025_osnap_to_jasmin_os.slurm
+++ b/jasmin_os/eORCA025/diags/run_send_eORCA025_osnap_to_jasmin_os.slurm
@@ -1,0 +1,44 @@
+#!/bin/bash
+#SBATCH --job-name=xfer_osnap_eORCA025
+#SBATCH --partition=compute
+#SBATCH --time=00:30:00
+#SBATCH --ntasks-per-core=1
+#SBATCH --ntasks-per-node=64
+#SBATCH --ntasks-per-socket=32
+#SBATCH --nodes=1
+
+# ==============================================================
+# run_send_eORCA025_osnap_to_jasmin_os.slurm
+#
+# Description: SLURM script to send the eORCA025 section 
+# variables for the OSNAP arrays to the JASMIN object store.
+#
+# Created By: Ollie Tooth (oliver.tooth@noc.ac.uk)
+# Created On: 2025-01-06
+#
+# ==============================================================
+# -- Input arguments to msm-os -- #
+# Filepath to eORCA025 OSNAP .zarr store:
+filepath_osnap=/dssgfs01/scratch/otooth/npd_data/simulations/eORCA025_JRA55/sections_npd_v1/osnap_npd_v1/eORCA025_1976_2024_OSNAP_section.zarr
+
+# Filepath to JASMIN OS credentials:
+store_credentials_json=/dssgfs01/working/otooth/AtlantiS/jasmin_os/credentials/jasmin_os_credentials.json
+
+# Bucket and object prefix:
+bucket=npd-eorca025-jra55v1
+
+# Variables - save entire dataset to single zarr store - and chunks:
+variables=compact
+
+# -- Python Environment -- #
+# Activate miniconda environment:
+source /home/otooth/miniconda3/etc/profile.d/conda.sh
+conda activate env_jasmin_os
+
+# -- Send METRIC eORCA025 monthly mean output to JASMIN OS -- #
+echo "In Progress: Sending eORCA025 monthly OSNAP outputs to JASMIN object store..."
+msm_os send_with_dask -f $filepath_osnap -c $store_credentials_json -b $bucket -p M1m/osnap -v $variables \
+                      -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/osnap/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/osnap/"}' \
+                      -dlc '{"n_workers":15,"threads_per_worker":4,"memory_limit":"3GB"}'
+
+echo "Completed: Sent eORCA025 monthly OSNAP outputs to JASMIN object store."

--- a/jasmin_os/eORCA025/domain/run_send_eORCA025_domain_to_jasmin_os.slurm
+++ b/jasmin_os/eORCA025/domain/run_send_eORCA025_domain_to_jasmin_os.slurm
@@ -1,0 +1,53 @@
+#!/bin/bash
+#SBATCH --job-name=xfer_domain_eORCA025
+#SBATCH --partition=compute
+#SBATCH --time=01:00:00
+#SBATCH --ntasks-per-core=1
+#SBATCH --ntasks-per-node=64
+#SBATCH --ntasks-per-socket=32
+#SBATCH --nodes=1
+
+# ==============================================================
+# run_send_eORCA025_domain_to_jasmin_os.slurm
+#
+# Description: SLURM script to send the eORCA025 model domain 
+# variables to the JASMIN object store.
+#
+# Created By: Ollie Tooth (oliver.tooth@noc.ac.uk)
+# Created On: 2025-01-02
+#
+# ==============================================================
+# -- Input arguments to msm-os -- #
+# Filepath to eORCA025 ancillary file:
+filepath_mesh_mask=/dssgfs01/scratch/npd/simulations/Domains/mesh_mask.nc
+filepath_subbasins=/dssgfs01/scratch/npd/simulations/Domains/subbasins.nc
+
+# Filepath to JASMIN OS credentials:
+store_credentials_json=.../credentials/jasmin_os_credentials.json
+
+# Bucket and object prefix:
+bucket=npd-eorca025-jra55v1
+object_prefix=domain
+
+# Variables - save entire dataset to single zarr store - and chunks:
+variables=compact
+
+# -- Python Environment -- #
+# Activate miniconda environment:
+source /home/otooth/miniconda3/etc/profile.d/conda.sh
+conda activate env_jasmin_os
+
+# -- Send ancillary files to JASMIN OS -- #
+echo "In Progress: Sending eORCA025 mesh mask file to JASMIN object store..."
+msm_os send_with_dask -f $filepath_mesh_mask -c $store_credentials_json -b $bucket -p $object_prefix -v $variables \
+                      -cs '{"x":480,"y":402}' \
+                      -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/"}' \
+                      -dlc '{"n_workers":5,"threads_per_worker":4,"memory_limit":"3GB"}'
+
+echo "In Progress: Sending eORCA025 sub-basins mask file to JASMIN object store..."
+msm_os send_with_dask -f $filepath_subbasins -c $store_credentials_json -b $bucket -p $object_prefix -v $variables \
+                      -cs '{"x":480,"y":402}' \
+                      -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/"}' \
+                      -dlc '{"n_workers":5,"threads_per_worker":4,"memory_limit":"3GB"}'
+
+echo "Completed: Sent eORCA025 ancillary files to JASMIN object store."

--- a/jasmin_os/eORCA1/1m/run_send_eORCA1_1m_to_jasmin_os.slurm
+++ b/jasmin_os/eORCA1/1m/run_send_eORCA1_1m_to_jasmin_os.slurm
@@ -1,0 +1,78 @@
+#!/bin/bash
+#SBATCH --job-name=xfer_1m_eORCA1
+#SBATCH --partition=compute
+#SBATCH --time=05:00:00
+#SBATCH --ntasks-per-core=1
+#SBATCH --ntasks-per-node=64
+#SBATCH --ntasks-per-socket=32
+#SBATCH --nodes=1
+
+# ==============================================================
+# run_send_eORCA1_1m_to_jasmin_os.slurm
+#
+# Description: SLURM script to send the eORCA1 monthly-mean 
+# output variables to the JASMIN object store.
+#
+# Created By: Ollie Tooth (oliver.tooth@noc.ac.uk)
+# Created On: 2025-01-02
+#
+# ==============================================================
+# -- Input arguments to msm-os -- #
+# Filepath to eORCA1 ancillary file:
+filepath_grid=/dssgfs01/scratch/otooth/npd_data/simulations/Domains/eORCA1/domain_cfg.nc
+
+# Filepath to eORCA1 monthly mean output files:
+filedir=/dssgfs01/scratch/otooth/npd_data/simulations/eORCA1_JRA55/exp_npd_v1
+filepath_gridT=$filedir/eORCA1_1m_grid_T_*.nc
+filepath_gridU=$filedir/eORCA1_1m_grid_U_*.nc
+filepath_gridV=$filedir/eORCA1_1m_grid_V_*.nc
+filepath_gridW=$filedir/eORCA1_1m_grid_W_*.nc
+filepath_scalar=$filedir/eORCA1_1m_scalar_*.nc
+
+# Filepath to JASMIN OS credentials:
+store_credentials_json=.../credentials/jasmin_os_credentials.json
+
+# Bucket and object prefix:
+bucket=npd-eorca1-jra55v1
+
+# -- Python Environment -- #
+# Activate miniconda environment:
+source /home/otooth/miniconda3/etc/profile.d/conda.sh
+conda activate env_jasmin_os
+
+# -- Send eORCA1 monthly mean outputs to JASMIN OS -- #
+echo "In Progress: Sending eORCA1 T1m variables to JASMIN object store..."
+msm_os send_with_dask -f $filepath_gridT -c $store_credentials_json -b $bucket -p T1m \
+                      -gf $filepath_grid -uc '{"nav_lon":"glamt", "nav_lat":"gphit"}' \
+                      -cs '{"x":360,"y":331,"deptht":25}' \
+                      -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/"}' \
+                      -dlc '{"n_workers":30,"threads_per_worker":1,"memory_limit":"2GB"}'
+
+echo "In Progress: Sending eORCA1 U1m variables to JASMIN object store..."
+msm_os send_with_dask -f $filepath_gridU -c $store_credentials_json -b $bucket -p U1m \
+                      -gf $filepath_grid -uc '{"nav_lon":"glamu", "nav_lat":"gphiu"}' \
+                      -cs '{"x":360,"y":331,"depthu":25}' \
+                      -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/"}' \
+                      -dlc '{"n_workers":30,"threads_per_worker":1,"memory_limit":"2GB"}'
+
+echo "In Progress: Sending eORCA1 V1m variables to JASMIN object store..."
+msm_os send_with_dask -f $filepath_gridV -c $store_credentials_json -b $bucket -p V1m \
+                      -gf $filepath_grid -uc '{"nav_lon":"glamv", "nav_lat":"gphiv"}' \
+                      -cs '{"x":360,"y":331,"depthv":25}' \
+                      -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/"}' \
+                      -dlc '{"n_workers":30,"threads_per_worker":1,"memory_limit":"2GB"}'
+
+echo "In Progress: Sending eORCA1 W1m variables to JASMIN object store..."
+msm_os send_with_dask -f $filepath_gridW -c $store_credentials_json -b $bucket -p W1m \
+                      -gf $filepath_grid -uc '{"nav_lon":"glamt", "nav_lat":"gphit"}' \
+                      -cs '{"x":360,"y":331,"depthw":25}' \
+                      -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/"}' \
+                      -dlc '{"n_workers":30,"threads_per_worker":1,"memory_limit":"2GB"}'
+
+echo "In Progress: Sending eORCA1 scalar variables to JASMIN object store..."
+msm_os send_with_dask -f $filepath_scalar -c $store_credentials_json -b $bucket -p S1m \
+                      -gf $filepath_grid -uc '{"nav_lon":"glamt", "nav_lat":"gphit"}' \
+                      -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/"}' \
+                      -dlc '{"n_workers":5,"threads_per_worker":1,"memory_limit":"2GB"}'
+
+echo "Completed: Sent eORCA1 monthly mean fields to JASMIN object store."

--- a/jasmin_os/eORCA1/1y/run_send_eORCA1_1y_to_jasmin_os.slurm
+++ b/jasmin_os/eORCA1/1y/run_send_eORCA1_1y_to_jasmin_os.slurm
@@ -1,0 +1,86 @@
+#!/bin/bash
+#SBATCH --job-name=xfer_1y_eORCA1
+#SBATCH --partition=compute
+#SBATCH --time=04:00:00
+#SBATCH --ntasks-per-core=1
+#SBATCH --ntasks-per-node=64
+#SBATCH --ntasks-per-socket=32
+#SBATCH --nodes=1
+
+# ==============================================================
+# run_send_eORCA1_1y_to_jasmin_os.slurm
+#
+# Description: SLURM script to send the eORCA1 annual-mean 
+# output variables to the JASMIN object store.
+#
+# Created By: Ollie Tooth (oliver.tooth@noc.ac.uk)
+# Created On: 2025-01-02
+#
+# ==============================================================
+# -- Input arguments to msm-os -- #
+# Filepath to eORCA1 ancillary file:
+filepath_grid=/dssgfs01/scratch/otooth/npd_data/simulations/Domains/eORCA1/domain_cfg.nc
+
+# Filepath to eORCA1 annual mean output files:
+filedir=/dssgfs01/scratch/otooth/npd_data/simulations/eORCA1_JRA55/exp_npd_v1
+filepath_gridT=$filedir/eORCA1_1y_grid_T_*.nc
+filepath_gridU=$filedir/eORCA1_1y_grid_U_*.nc
+filepath_gridV=$filedir/eORCA1_1y_grid_V_*.nc
+filepath_gridW=$filedir/eORCA1_1y_grid_W_*.nc
+filepath_icemod=$filedir/eORCA1_1y_icemod_*.nc
+filepath_scalar=$filedir/eORCA1_1y_scalar_*.nc
+
+# Filepath to JASMIN OS credentials:
+store_credentials_json=.../credentials/jasmin_os_credentials.json
+
+# Bucket and object prefix:
+bucket=npd-eorca1-jra55v1
+
+# -- Python Environment -- #
+# Activate miniconda environment:
+source /home/otooth/miniconda3/etc/profile.d/conda.sh
+conda activate env_jasmin_os
+
+# -- Send eORCA1 annual mean outputs to JASMIN OS -- # 
+echo "In Progress: Sending eORCA1 T1y variables to JASMIN object store..."
+msm_os send_with_dask -f $filepath_gridT -c $store_credentials_json -b $bucket -p T1y \
+                      -gf $filepath_grid -uc '{"nav_lon":"glamt", "nav_lat":"gphit"}' \
+                      -cs '{"x":360,"y":331,"deptht":25}' \
+                      -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/"}' \
+                      -dlc '{"n_workers":30,"threads_per_worker":1,"memory_limit":"2GB"}'
+
+echo "In Progress: Sending eORCA1 U1y variables to JASMIN object store..."
+msm_os send_with_dask -f $filepath_gridU -c $store_credentials_json -b $bucket -p U1y \
+                      -gf $filepath_grid -uc '{"nav_lon":"glamu", "nav_lat":"gphiu"}' \
+                      -cs '{"x":360,"y":331,"depthu":25}' \
+                      -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/"}' \
+                      -dlc '{"n_workers":30,"threads_per_worker":1,"memory_limit":"2GB"}'
+
+echo "In Progress: Sending eORCA1 V1y variables to JASMIN object store..."
+msm_os send_with_dask -f $filepath_gridV -c $store_credentials_json -b $bucket -p V1y \
+                      -gf $filepath_grid -uc '{"nav_lon":"glamv", "nav_lat":"gphiv"}' \
+                      -cs '{"x":360,"y":331,"depthv":25}' \
+                      -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/"}' \
+                      -dlc '{"n_workers":30,"threads_per_worker":1,"memory_limit":"2GB"}'
+
+echo "In Progress: Sending eORCA1 W1y variables to JASMIN object store..."
+msm_os send_with_dask -f $filepath_gridW -c $store_credentials_json -b $bucket -p W1y \
+                      -gf $filepath_grid -uc '{"nav_lon":"glamt", "nav_lat":"gphit"}' \
+                      -cs '{"x":360,"y":331,"depthw":25}' \
+                      -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/"}' \
+                      -dlc '{"n_workers":30,"threads_per_worker":1,"memory_limit":"2GB"}'
+
+echo "In Progress: Sending eORCA1 I1y variables to JASMIN object store..."
+msm_os send_with_dask -f $filepath_icemod -c $store_credentials_json -b $bucket -p I1y \
+                      -gf $filepath_grid -uc '{"nav_lon":"glamt", "nav_lat":"gphit"}' \
+                      -cs '{"x":360,"y":331}' \
+                      -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/"}' \
+                      -dlc '{"n_workers":30,"threads_per_worker":1,"memory_limit":"2GB"}'
+
+echo "In Progress: Sending eORCA1 S1y variables to JASMIN object store..."
+msm_os send_with_dask -f $filepath_scalar -c $store_credentials_json -b $bucket -p S1y \
+                      -gf $filepath_grid -uc '{"nav_lon":"glamt", "nav_lat":"gphit"}' \
+                      -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/"}' \
+                      -dlc '{"n_workers":5,"threads_per_worker":1,"memory_limit":"2GB"}'
+
+echo "Completed: Sent eORCA1 monthly mean fields to JASMIN object store."

--- a/jasmin_os/eORCA1/diags/run_send_eORCA1_metric_to_jasmin_os.slurm
+++ b/jasmin_os/eORCA1/diags/run_send_eORCA1_metric_to_jasmin_os.slurm
@@ -1,0 +1,57 @@
+#!/bin/bash
+#SBATCH --job-name=xfer_metric_eORCA1
+#SBATCH --partition=compute
+#SBATCH --time=00:30:00
+#SBATCH --ntasks-per-core=1
+#SBATCH --ntasks-per-node=64
+#SBATCH --ntasks-per-socket=32
+#SBATCH --nodes=1
+
+# ==============================================================
+# run_send_eORCA1_metric_to_jasmin_os.slurm
+#
+# Description: SLURM script to send the eORCA1 METRIC section 
+# variables for the RAPID, MOVE and SAMBA arrays to the JASMIN
+# object store.
+#
+# Created By: Ollie Tooth (oliver.tooth@noc.ac.uk)
+# Created On: 2025-01-02
+#
+# ==============================================================
+# -- Input arguments to msm-os -- #
+# Filepath to eORCA1 ancillary file:
+filepath_rapid=/dssgfs01/scratch/otooth/npd_data/simulations/eORCA1_JRA55/metric_npd_v1/eORCA1_1976-01-2024-01_natl_meridional_transports_at_26N.nc
+filepath_move=/dssgfs01/scratch/otooth/npd_data/simulations/eORCA1_JRA55/metric_npd_v1/eORCA1_1976-01-2024-01_natl_meridional_transports_at_16N.nc
+filepath_samba=/dssgfs01/scratch/otooth/npd_data/simulations/eORCA1_JRA55/metric_npd_v1/eORCA1_1976-01-2024-01_natl_meridional_transports_at_34_5S.nc
+
+# Filepath to JASMIN OS credentials:
+store_credentials_json=.../credentials/jasmin_os_credentials.json
+
+# Bucket and object prefix:
+bucket=npd-eorca1-jra55v1
+
+# Variables - save entire dataset to single zarr store - and chunks:
+variables=compact
+
+# -- Python Environment -- #
+# Activate miniconda environment:
+source /home/otooth/miniconda3/etc/profile.d/conda.sh
+conda activate env_jasmin_os
+
+# -- Send METRIC eORCA1 monthly mean output to JASMIN OS -- #
+echo "In Progress: Sending eORCA1 monthly METRIC RAPID 26.5N outputs to JASMIN object store..."
+msm_os send_with_dask -f $filepath_rapid -c $store_credentials_json -b $bucket -p M1m/rapid_26N -v $variables \
+                      -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/"}' \
+                      -dlc '{"n_workers":10,"threads_per_worker":4,"memory_limit":"3GB"}'
+
+echo "In Progress: Sending eORCA1 monthly METRIC MOVE 16N outputs to JASMIN object store..."
+msm_os send_with_dask -f $filepath_move -c $store_credentials_json -b $bucket -p M1m/move_16N -v $variables \
+                      -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/"}' \
+                      -dlc '{"n_workers":10,"threads_per_worker":4,"memory_limit":"3GB"}'
+
+echo "In Progress: Sending eORCA1 monthly METRIC SAMBA 34.5S outputs to JASMIN object store..."
+msm_os send_with_dask -f $filepath_samba -c $store_credentials_json -b $bucket -p M1m/samba_34_5S -v $variables \
+                      -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/"}' \
+                      -dlc '{"n_workers":10,"threads_per_worker":4,"memory_limit":"3GB"}'
+
+echo "Completed: Sent eORCA1 monthly METRIC outputs to JASMIN object store."

--- a/jasmin_os/eORCA1/diags/run_send_eORCA1_osnap_to_jasmin_os.slurm
+++ b/jasmin_os/eORCA1/diags/run_send_eORCA1_osnap_to_jasmin_os.slurm
@@ -1,0 +1,45 @@
+#!/bin/bash
+#SBATCH --job-name=xfer_osnap_eORCA1
+#SBATCH --partition=compute
+#SBATCH --time=00:30:00
+#SBATCH --ntasks-per-core=1
+#SBATCH --ntasks-per-node=64
+#SBATCH --ntasks-per-socket=32
+#SBATCH --nodes=1
+
+# ==============================================================
+# run_send_eORCA1_osnap_to_jasmin_os.slurm
+#
+# Description: SLURM script to send the eORCA1 OSNAP section 
+# variables for the RAPID, MOVE and SAMBA arrays to the JASMIN
+# object store.
+#
+# Created By: Ollie Tooth (oliver.tooth@noc.ac.uk)
+# Created On: 2025-01-06
+#
+# ==============================================================
+# -- Input arguments to msm-os -- #
+# Filepath to eORCA1 OSNAP .zarr store:
+filepath_osnap=/dssgfs01/scratch/otooth/npd_data/simulations/eORCA1_JRA55/sections_npd_v1/osnap_npd_v1/eORCA1_1976_2024_OSNAP_section.zarr
+
+# Filepath to JASMIN OS credentials:
+store_credentials_json=/dssgfs01/working/otooth/AtlantiS/jasmin_os/credentials/jasmin_os_credentials.json
+
+# Bucket and object prefix:
+bucket=npd-eorca1-jra55v1
+
+# Variables - save entire dataset to single zarr store - and chunks:
+variables=compact
+
+# -- Python Environment -- #
+# Activate miniconda environment:
+source /home/otooth/miniconda3/etc/profile.d/conda.sh
+conda activate env_jasmin_os
+
+# -- Send osnap eORCA1 monthly mean output to JASMIN OS -- #
+echo "In Progress: Sending eORCA1 monthly OSNAP array outputs to JASMIN object store..."
+msm_os send_with_dask -f $filepath_osnap -c $store_credentials_json -b $bucket -p M1m/osnap -v $variables \
+                      -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/osnap/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/osnap/"}' \
+                      -dlc '{"n_workers":15,"threads_per_worker":4,"memory_limit":"3GB"}'
+
+echo "Completed: Sent eORCA1 monthly OSNAP outputs to JASMIN object store."

--- a/jasmin_os/eORCA1/domain/run_send_eORCA1_domain_to_jasmin_os.slurm
+++ b/jasmin_os/eORCA1/domain/run_send_eORCA1_domain_to_jasmin_os.slurm
@@ -1,0 +1,53 @@
+#!/bin/bash
+#SBATCH --job-name=xfer_domain_eORCA1
+#SBATCH --partition=compute
+#SBATCH --time=01:00:00
+#SBATCH --ntasks-per-core=1
+#SBATCH --ntasks-per-node=64
+#SBATCH --ntasks-per-socket=32
+#SBATCH --nodes=1
+
+# ==============================================================
+# run_send_eORCA1_domain_to_jasmin_os.slurm
+#
+# Description: SLURM script to send the eORCA1 model domain 
+# variables to the JASMIN object store.
+#
+# Created By: Ollie Tooth (oliver.tooth@noc.ac.uk)
+# Created On: 2025-01-02
+#
+# ==============================================================
+# -- Input arguments to msm-os -- #
+# Filepath to eORCA1 ancillary file:
+filepath_mesh_mask=/dssgfs01/working/atb299/NEMO_cfgs/NPD_eORCA1_v4.2/domain_cfg.nc
+filepath_subbasins=/dssgfs01/working/atb299/NEMO_cfgs/NPD_eORCA1_v4.2/subbasins_CMIP6.nc
+
+# Filepath to JASMIN OS credentials:
+store_credentials_json=.../credentials/jasmin_os_credentials.json
+
+# Bucket and object prefix:
+bucket=npd-eorca1-jra55v1
+object_prefix=domain
+
+# Variables - save entire dataset to single zarr store - and chunks:
+variables=compact
+
+# -- Python Environment -- #
+# Activate miniconda environment:
+source /home/otooth/miniconda3/etc/profile.d/conda.sh
+conda activate env_jasmin_os
+
+# -- Send ancillary files to JASMIN OS -- #
+echo "In Progress: Sending eORCA1 mesh mask file to JASMIN object store..."
+msm_os send_with_dask -f $filepath_mesh_mask -c $store_credentials_json -b $bucket -p $object_prefix -v $variables \
+                      -cs '{"x":360,"y":331}' \
+                      -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/"}' \
+                      -dlc '{"n_workers":3,"threads_per_worker":4,"memory_limit":"3GB"}'
+
+echo "In Progress: Sending eORCA1 sub-basins mask file to JASMIN object store..."
+msm_os send_with_dask -f $filepath_subbasins -c $store_credentials_json -b $bucket -p $object_prefix -v $variables \
+                      -cs '{"x":360,"y":331}' \
+                      -dco '{"temporary_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/","local_directory":"/dssgfs01/scratch/otooth/NOC_NPD/20250102/NOC_Near_Present_Day/jasmin_os/tmp/"}' \
+                      -dlc '{"n_workers":3,"threads_per_worker":4,"memory_limit":"3GB"}'
+
+echo "Completed: Sent eORCA1 ancillary files to JASMIN object store."

--- a/jasmin_os/intake/create_npd_variable_inventory.py
+++ b/jasmin_os/intake/create_npd_variable_inventory.py
@@ -42,4 +42,4 @@ for model in ['eORCA1', 'eORCA025']:
                         df_inv.loc[len(df_inv)] = [var, attrs['standard_name'].lower(), attrs['long_name'].lower(), attrs['units'], ds[var].dims, model, grid, freq, url]
 
 # Save inventory DataFrame to CSV file:
-df_inv.to_csv('.../NOC_Near_Present_Day/jasmin_os/intake/npd_variable_inventory.csv', index=False)
+df_inv.to_csv('.../NOC_Near_Present_Day/jasmin_os/intake/npd_v1_variable_inventory.csv', index=False)

--- a/jasmin_os/intake/create_npd_variable_inventory.py
+++ b/jasmin_os/intake/create_npd_variable_inventory.py
@@ -1,0 +1,45 @@
+"""
+create_npd_variable_inventory.py
+
+Description: This script creates a variable inventory for the National
+Oceanography Centre's Near-Present-Day (NPD) JRA55 version 1 simulation
+outputs. The variabe inventory is saved as a CSV file.
+
+Created By: Ollie Tooth (oliver.tooth@noc.ac.uk)
+Creation Date: 2025-01-10
+"""
+# -- Import required packages -- #
+import glob
+import pandas as pd
+import xarray as xr
+
+# -- Create inventory DataFrame -- #
+# Define empty dataframe:
+df_inv = pd.DataFrame(columns=['variable', 'standard_name', 'long_name', 'units', 'dims', 'model', 'grid', 'freq', 'url'])
+
+# Iterate over models, grids, and output frequencies:
+for model in ['eORCA1', 'eORCA025']:
+    for grid in ['T', 'U', 'V', 'W']:
+        for freq in ['5d', '1m', '1y']:
+            # Ignore eORCA1 5d frequency since this is not available:
+            if (model == 'eORCA1') & (freq == '5d'):
+                continue
+            else:
+                # Open example dataset to get variable metadata:
+                filepaths = glob.glob(f'/dssgfs01/scratch/otooth/npd_data/simulations/{model}_JRA55/exp_npd_v1/{model}_{freq}_grid_{grid}*.nc')
+                filepaths.sort()
+                ds = xr.open_dataset(filepaths[0])
+                # Iterate over available variables:
+                for var in ds.data_vars:
+                    attrs = ds[var].attrs
+                    # Ignore variables without standard_name attribute (e.g. coordinate dimensions):
+                    if 'standard_name' not in attrs:
+                        continue
+                    else:
+                        # Create JASMIN OS read-only URL:
+                        url = f'https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-{model.lower()}-jra55v1/{grid}{freq}/{var}'
+                        # Append variable metadata to inventory dataframe:
+                        df_inv.loc[len(df_inv)] = [var, attrs['standard_name'].lower(), attrs['long_name'].lower(), attrs['units'], ds[var].dims, model, grid, freq, url]
+
+# Save inventory DataFrame to CSV file:
+df_inv.to_csv('.../NOC_Near_Present_Day/jasmin_os/intake/npd_variable_inventory.csv', index=False)

--- a/jasmin_os/intake/npd_v1_catalog.yaml
+++ b/jasmin_os/intake/npd_v1_catalog.yaml
@@ -1,0 +1,75 @@
+plugins:
+  source:
+    - module: intake_xarray
+
+sources:
+  variable_inventory:
+    args:
+      keep_default_na: false
+      urlpath: '{{ CATALOG_DIR }}/npd_variable_inventory.csv'
+    description: Inventory of output variables available from the NOC Near-Present Day (NPD) simulations.
+    driver: intake.source.csv.CSVSource
+    metadata: {}
+  eORCA1_JRA55v1:
+    description: National Oceanography Centre (NOC) eORCA1-JRA55v1 Near-Present-Day ocean-sea ice simulation output. The eORCA1-JRA55v1 configuration consists of a 1 degree global ocean model (NEMO v4.2) with 75 z* vertical levels coupled to the Sea Ice modelling Integrated Initiative (SI3) sea ice model. The atmospheric forcing is provided by the Japanese 55-year Reanalysis (JRA55-do) for the period 1976-2023. The simulation is initialised using World Ocean Atlas 2023 conservative temperature and absolute salinity climatologies (1971-2000 average) and begins with a 3-year spin-up period using repeated 1976 JRA55-do atmospheric forcing. For more information see https://noc-msm.github.io/NOC_Near_Present_Day.
+    metadata:
+      description: National Oceanography Centre (NOC) eORCA1-JRA55v1 Near-Present-Day ocean-sea ice simulation output. The eORCA1-JRA55v1 configuration consists of a 1 degree global ocean model (NEMO v4.2) with 75 z* vertical levels coupled to the Sea Ice modelling Integrated Initiative (SI3) sea ice model. The atmospheric forcing is provided by the Japanese 55-year Reanalysis (JRA55-do) for the period 1976-2023. The simulation is initialised using World Ocean Atlas 2023 conservative temperature and absolute salinity climatologies (1971-2000 average) and begins with a 3-year spin-up period using repeated 1976 JRA55-do atmospheric forcing. For more information see https://noc-msm.github.io/NOC_Near_Present_Day.
+      url: 'https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1'
+      tags:
+        - ocean
+        - model
+        - npd
+        - jra55
+        - forced
+    args:
+      consolidated: true
+      urlpath:
+      - https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/{{grid}}{{freq}}/{{var}}
+    driver: intake_xarray.xzarr.ZarrSource
+    parameters:
+      grid:
+        default: T
+        description: Grid defining where output variables are stored.
+        allowed: ["T", "U", "V", "W", "I", "S", "M"]
+        type: str
+      freq:
+        default: 1y
+        description: Temporal frequency at which output variables are stored.
+        allowed: ["1y", "1m"]
+        type: str
+      var:
+        default: thetao_con
+        description: Name of the output variable.
+        type: str
+
+  eORCA025_JRA55v1:
+    description: National Oceanography Centre (NOC) eORCA025-JRA55v1 Near-Present-Day ocean-sea ice simulation output. The eORCA025-JRA55v1 configuration consists of a 1/4 degree global ocean model (NEMO v4.2) with 75 z* vertical levels coupled to the Sea Ice modelling Integrated Initiative (SI3) sea ice model. The atmospheric forcing is provided by the Japanese 55-year Reanalysis (JRA55-do) for the period 1976-2023. The simulation is initialised using World Ocean Atlas 2023 conservative temperature and absolute salinity climatologies (1971-2000 average) and begins with a 3-year spin-up period using repeated 1976 JRA55-do atmospheric forcing. For more information see https://noc-msm.github.io/NOC_Near_Present_Day.
+    metadata:
+      description: National Oceanography Centre (NOC) eORCA025-JRA55v1 Near-Present-Day ocean-sea ice simulation output. The eORCA025-JRA55v1 configuration consists of a 1/4 degree global ocean model (NEMO v4.2) with 75 z* vertical levels coupled to the Sea Ice modelling Integrated Initiative (SI3) sea ice model. The atmospheric forcing is provided by the Japanese 55-year Reanalysis (JRA55-do) for the period 1976-2023. The simulation is initialised using World Ocean Atlas 2023 conservative temperature and absolute salinity climatologies (1971-2000 average) and begins with a 3-year spin-up period using repeated 1976 JRA55-do atmospheric forcing. For more information see https://noc-msm.github.io/NOC_Near_Present_Day.
+      url: 'https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1'
+      tags:
+        - ocean
+        - model
+        - npd
+        - jra55
+        - forced
+    args:
+      consolidated: true
+      urlpath:
+      - https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/{{grid}}{{freq}}/{{var}}
+    driver: intake_xarray.xzarr.ZarrSource
+    parameters:
+      grid:
+        default: T
+        description: Grid defining where output variables are stored.
+        allowed: ["T", "U", "V", "W", "I", "S", "M"]
+        type: str
+      freq:
+        default: 1y
+        description: Temporal frequency at which output variables are stored.
+        allowed: ["1y", "1m", "5d"]
+        type: str
+      var:
+        default: thetao_con
+        description: Name of the output variable.
+        type: str

--- a/jasmin_os/intake/npd_v1_catalog.yaml
+++ b/jasmin_os/intake/npd_v1_catalog.yaml
@@ -6,7 +6,7 @@ sources:
   variable_inventory:
     args:
       keep_default_na: false
-      urlpath: '{{ CATALOG_DIR }}/npd_variable_inventory.csv'
+      urlpath: '{{ CATALOG_DIR }}npd_v1_variable_inventory.csv'
     description: Inventory of output variables available from the NOC Near-Present Day (NPD) simulations.
     driver: intake.source.csv.CSVSource
     metadata: {}

--- a/jasmin_os/intake/npd_v1_variable_inventory.csv
+++ b/jasmin_os/intake/npd_v1_variable_inventory.csv
@@ -1,0 +1,395 @@
+variable,standard_name,long_name,units,dims,model,grid,freq,url
+e3t,cell_thickness,t-cell thickness,m,"('time_counter', 'deptht', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/e3t
+thetao_con,sea_water_conservative_temperature,sea_water_conservative_temperature,degC,"('time_counter', 'deptht', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/thetao_con
+so_abs,sea_water_absolute_salinity,sea_water_absolute_salinity,g/kg,"('time_counter', 'deptht', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/so_abs
+zos,sea_surface_height_above_geoid,sea surface height above geoid,m,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/zos
+zossq,square_of_sea_surface_height_above_geoid,square of sea surface height above geoid,m2,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/zossq
+friver,water_flux_into_sea_water_from_rivers,river runoffs,kg/m2/s,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/friver
+hfto,surface_net_downward_total_heat_flux,net downward heat flux,W/m2,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/hfto
+hfsr,surface_net_downward_solar_heat_flux,shortwave radiation,W/m2,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/hfsr
+hfns,surface_net_downward_non_solar_heat_flux,non solar downward heat flux,W/m2,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/hfns
+rsdo,downwelling_shortwave_flux_in_sea_water,shortwave radiation 3d distribution,W/m2,"('time_counter', 'deptht', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/rsdo
+hfds,ocean_surface_downward_total_heat_flux,total flux at ocean surface,W/m2,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/hfds
+rlntds,ocean_surface_net_downward_longwave_heat_flux,longwave downward heat flux over open ocean,W/m2,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/rlntds
+hfss,ocean_surface_downward_sensible_heat_flux,sensible downward heat flux over open ocean,W/m2,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/hfss
+hfls,ocean_surface_downward_latent_heat_flux,latent downward heat flux over open ocean,W/m2,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/hfls
+hfempds,ocean_surface_downward_heat_flux_from_e-p,downward heat flux from e-p over open ocean,W/m2,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/hfempds
+rsntds,ocean_surface_net_downward_shortwave_heat_flux,solar heat flux at ocean surface,W/m2,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/rsntds
+mlotst,ocean_mixed_layer_thickness_defined_by_sigma_theta,ocean mixed layer thickness defined by sigma t,m,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/mlotst
+mlotstsq,square_of_ocean_mixed_layer_thickness_defined_by_sigma_theta,square of ocean mixed layer thickness defined by sigma t,m,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/mlotstsq
+mlotstmax,ocean_mixed_layer_thickness_defined_by_sigma_theta,ocean mixed layer thickness defined by sigma t,m,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/mlotstmax
+mlotstmin,ocean_mixed_layer_thickness_defined_by_sigma_theta,ocean mixed layer thickness defined by sigma t,m,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/mlotstmin
+ficeberg,water_flux_into_sea_water_from_icebergs,icb melt rate of icebergs,kg/m2/s,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/ficeberg
+berg_latent_heat_flux,latent_heat_flux_from_icebergs,icb heat flux to ocean due to melting latent heat,J/m2/s,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/berg_latent_heat_flux
+pbo,sea_water_pressure_at_sea_floor,sea water pressure at sea floor,dbar,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/pbo
+tos_con,sea_surface_temperature,sea_surface_conservative_temperature,degC,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/tos_con
+tossq_con,square_of_sea_surface_temperature,square_of_sea_surface_conservative_temperature,degC2,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/tossq_con
+sos_abs,sea_surface_salinity,sea_surface_absolute_salinity,g/kg,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/sos_abs
+sossq_abs,square_of_sea_surface_salinity,square of sea surface salinity,1e-6,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/sossq_abs
+evs,water_evaporation_flux,water evaporation flux where ice free ocean over sea,kg/m2/s,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/evs
+prsn,snowfall_flux,snowfall flux,kg/m2/s,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/prsn
+hfrainds,temperature_flux_due_to_rain_expressed_as_heat_flux_into_sea_water,temperature flux due to rain expressed as heat flux in to sea water,W/m2,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/hfrainds
+hfevapds,temperature_flux_due_to_evaporation_expressed_as_heat_flux_out_of_sea_water,temperature flux due to evaporation expressed as heat flux out of sea water,W/m2,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/hfevapds
+hflx_rnf,temperature_flux_due_to_runoff_expressed_as_heat_flux_into_sea_water,temperature flux due to runoff expressed as heat flux into  sea water,W/m2,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/hflx_rnf
+sfdsi,downward_sea_ice_basal_salt_flux,downward salt flux,g/m2/s,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/sfdsi
+empmr,water_flux_out_of_sea_ice_and_sea_water,net upward water flux,kg/m2/s,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/empmr
+snowpre,snowfall_flux,snow precipitation,kg/m2/s,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/snowpre
+snow_ai_cea,snowfall_flux,snow over sea-ice (cell average),kg/m2/s,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/snow_ai_cea
+sowaflup,water_flux_out_of_sea_ice_and_sea_water,net upward water flux,kg/m2/s,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/sowaflup
+sosafldo,salt_flux_into_sea_water,downward salt flux,g/m2/s,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/sosafldo
+somixhgt,ocean_mixed_layer_thickness_defined_by_vertical_tracer_diffusivity,turbocline depth (kz = 5e-4),m,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/somixhgt
+somxl010,ocean_mixed_layer_thickness_defined_by_sigma_theta,mixed layer depth (dsigma = 0.01 wrt 10m),m,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/somxl010
+somxzint1,ocean_mixed_layer_thickness_defined_by_sigma_theta,mixed layer depth interpolated,m,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/somxzint1
+soicecov,sea_ice_area_fraction,ice fraction,1,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/soicecov
+sowindsp,wind_speed,wind speed module,m/s,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/sowindsp
+sohflisf,,ice shelf latent heat flux,W/m2,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/sohflisf
+vohflisf,,ice shelf latent heat flux ( from isf to oce ),W/m2,"('time_counter', 'deptht', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/vohflisf
+sohfcisf,,ice shelf heat content flux,W/m2,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/sohfcisf
+vohfcisf,,ice shelf heat content flux of injected water ( from isf to oce ),W/m2,"('time_counter', 'deptht', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/vohfcisf
+sowflisf,,ice shelf melting,kg/m2/s,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/sowflisf
+vowflisf,,3d ice shelf fresh water flux ( from isf to oce ),kg/m2/s,"('time_counter', 'deptht', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/vowflisf
+ocontempmint,integral_wrt_depth_of_product_of_density_and_conservative_temperature,vertical integral of conservative temperature times density,(kg m2) degree_C,"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/ocontempmint
+somint_abs,integral_wrt_depth_of_product_of_density_and_absolute_salinity,vertical integral of absolute salinity times density,(kg m2) x (1e-3),"('time_counter', 'y', 'x')",eORCA1,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1m/somint_abs
+e3t,cell_thickness,t-cell thickness,m,"('time_counter', 'deptht', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/e3t
+thetao_con,sea_water_conservative_temperature,sea_water_conservative_temperature,degC,"('time_counter', 'deptht', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/thetao_con
+so_abs,sea_water_absolute_salinity,sea_water_absolute_salinity,g/kg,"('time_counter', 'deptht', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/so_abs
+zos,sea_surface_height_above_geoid,sea surface height above geoid,m,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/zos
+zossq,square_of_sea_surface_height_above_geoid,square of sea surface height above geoid,m2,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/zossq
+friver,water_flux_into_sea_water_from_rivers,river runoffs,kg/m2/s,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/friver
+hfto,surface_net_downward_total_heat_flux,net downward heat flux,W/m2,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/hfto
+hfsr,surface_net_downward_solar_heat_flux,shortwave radiation,W/m2,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/hfsr
+hfns,surface_net_downward_non_solar_heat_flux,non solar downward heat flux,W/m2,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/hfns
+rsdo,downwelling_shortwave_flux_in_sea_water,shortwave radiation 3d distribution,W/m2,"('time_counter', 'deptht', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/rsdo
+hfds,ocean_surface_downward_total_heat_flux,total flux at ocean surface,W/m2,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/hfds
+rlntds,ocean_surface_net_downward_longwave_heat_flux,longwave downward heat flux over open ocean,W/m2,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/rlntds
+hfss,ocean_surface_downward_sensible_heat_flux,sensible downward heat flux over open ocean,W/m2,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/hfss
+hfls,ocean_surface_downward_latent_heat_flux,latent downward heat flux over open ocean,W/m2,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/hfls
+hfempds,ocean_surface_downward_heat_flux_from_e-p,downward heat flux from e-p over open ocean,W/m2,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/hfempds
+rsntds,ocean_surface_net_downward_shortwave_heat_flux,solar heat flux at ocean surface,W/m2,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/rsntds
+mlotst,ocean_mixed_layer_thickness_defined_by_sigma_theta,ocean mixed layer thickness defined by sigma t,m,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/mlotst
+mlotstsq,square_of_ocean_mixed_layer_thickness_defined_by_sigma_theta,square of ocean mixed layer thickness defined by sigma t,m,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/mlotstsq
+mlotstmax,ocean_mixed_layer_thickness_defined_by_sigma_theta,ocean mixed layer thickness defined by sigma t,m,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/mlotstmax
+mlotstmin,ocean_mixed_layer_thickness_defined_by_sigma_theta,ocean mixed layer thickness defined by sigma t,m,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/mlotstmin
+ficeberg,water_flux_into_sea_water_from_icebergs,icb melt rate of icebergs,kg/m2/s,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/ficeberg
+berg_latent_heat_flux,latent_heat_flux_from_icebergs,icb heat flux to ocean due to melting latent heat,J/m2/s,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/berg_latent_heat_flux
+pbo,sea_water_pressure_at_sea_floor,sea water pressure at sea floor,dbar,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/pbo
+tos_con,sea_surface_temperature,sea_surface_conservative_temperature,degC,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/tos_con
+tossq_con,square_of_sea_surface_temperature,square_of_sea_surface_conservative_temperature,degC2,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/tossq_con
+sos_abs,sea_surface_salinity,sea_surface_absolute_salinity,g/kg,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/sos_abs
+sossq_abs,square_of_sea_surface_salinity,square of sea surface salinity,1e-6,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/sossq_abs
+evs,water_evaporation_flux,water evaporation flux where ice free ocean over sea,kg/m2/s,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/evs
+prsn,snowfall_flux,snowfall flux,kg/m2/s,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/prsn
+hfrainds,temperature_flux_due_to_rain_expressed_as_heat_flux_into_sea_water,temperature flux due to rain expressed as heat flux in to sea water,W/m2,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/hfrainds
+hfevapds,temperature_flux_due_to_evaporation_expressed_as_heat_flux_out_of_sea_water,temperature flux due to evaporation expressed as heat flux out of sea water,W/m2,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/hfevapds
+hflx_rnf,temperature_flux_due_to_runoff_expressed_as_heat_flux_into_sea_water,temperature flux due to runoff expressed as heat flux into  sea water,W/m2,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/hflx_rnf
+sfdsi,downward_sea_ice_basal_salt_flux,downward salt flux,g/m2/s,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/sfdsi
+empmr,water_flux_out_of_sea_ice_and_sea_water,net upward water flux,kg/m2/s,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/empmr
+snowpre,snowfall_flux,snow precipitation,kg/m2/s,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/snowpre
+snow_ai_cea,snowfall_flux,snow over sea-ice (cell average),kg/m2/s,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/snow_ai_cea
+sowaflup,water_flux_out_of_sea_ice_and_sea_water,net upward water flux,kg/m2/s,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/sowaflup
+sosafldo,salt_flux_into_sea_water,downward salt flux,g/m2/s,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/sosafldo
+somixhgt,ocean_mixed_layer_thickness_defined_by_vertical_tracer_diffusivity,turbocline depth (kz = 5e-4),m,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/somixhgt
+somxl010,ocean_mixed_layer_thickness_defined_by_sigma_theta,mixed layer depth (dsigma = 0.01 wrt 10m),m,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/somxl010
+somxzint1,ocean_mixed_layer_thickness_defined_by_sigma_theta,mixed layer depth interpolated,m,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/somxzint1
+soicecov,sea_ice_area_fraction,ice fraction,1,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/soicecov
+sowindsp,wind_speed,wind speed module,m/s,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/sowindsp
+sohflisf,,ice shelf latent heat flux,W/m2,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/sohflisf
+vohflisf,,ice shelf latent heat flux ( from isf to oce ),W/m2,"('time_counter', 'deptht', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/vohflisf
+sohfcisf,,ice shelf heat content flux,W/m2,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/sohfcisf
+vohfcisf,,ice shelf heat content flux of injected water ( from isf to oce ),W/m2,"('time_counter', 'deptht', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/vohfcisf
+sowflisf,,ice shelf melting,kg/m2/s,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/sowflisf
+vowflisf,,3d ice shelf fresh water flux ( from isf to oce ),kg/m2/s,"('time_counter', 'deptht', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/vowflisf
+ocontempmint,integral_wrt_depth_of_product_of_density_and_conservative_temperature,vertical integral of conservative temperature times density,(kg m2) degree_C,"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/ocontempmint
+somint_abs,integral_wrt_depth_of_product_of_density_and_absolute_salinity,vertical integral of absolute salinity times density,(kg m2) x (1e-3),"('time_counter', 'y', 'x')",eORCA1,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/T1y/somint_abs
+e3u,cell_thickness,u-cell thickness,m,"('time_counter', 'depthu', 'y', 'x')",eORCA1,U,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/U1m/e3u
+uo,sea_water_x_velocity,ocean current along i-axis,m/s,"('time_counter', 'depthu', 'y', 'x')",eORCA1,U,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/U1m/uo
+uo_eiv,bolus_sea_water_x_velocity,eiv ocean current along i-axis,m/s,"('time_counter', 'depthu', 'y', 'x')",eORCA1,U,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/U1m/uo_eiv
+tauuo,surface_downward_x_stress,wind stress along i-axis,N/m2,"('time_counter', 'y', 'x')",eORCA1,U,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/U1m/tauuo
+u2o,square_of_sea_water_x_velocity,uu,m/s,"('time_counter', 'depthu', 'y', 'x')",eORCA1,U,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/U1m/u2o
+umo,ocean_mass_x_transport,ocean mass x transport,kg/s,"('time_counter', 'depthu', 'y', 'x')",eORCA1,U,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/U1m/umo
+umo_vint,vertical_integral_of_ocean_mass_x_transport,vertical integral of ocean eulerian mass transport along i-axis,kg/s,"('time_counter', 'y', 'x')",eORCA1,U,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/U1m/umo_vint
+hfx,ocean_heat_x_transport,ocean eulerian heat transport along i-axis,W,"('time_counter', 'y', 'x')",eORCA1,U,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/U1m/hfx
+hfx_adv,advectice_ocean_heat_x_transport,ocean advective heat transport along i-axis,W,"('time_counter', 'y', 'x')",eORCA1,U,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/U1m/hfx_adv
+hfx_diff,ocean_heat_x_transport_due_to_diffusion,ocean diffusion heat transport along i-axis,W,"('time_counter', 'y', 'x')",eORCA1,U,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/U1m/hfx_diff
+sozosatr,ocean_salt_x_transport,ocean eulerian salt transport along i-axis,1e-3*kg/s,"('time_counter', 'y', 'x')",eORCA1,U,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/U1m/sozosatr
+e3u,cell_thickness,u-cell thickness,m,"('time_counter', 'depthu', 'y', 'x')",eORCA1,U,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/U1y/e3u
+uo,sea_water_x_velocity,ocean current along i-axis,m/s,"('time_counter', 'depthu', 'y', 'x')",eORCA1,U,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/U1y/uo
+uo_eiv,bolus_sea_water_x_velocity,eiv ocean current along i-axis,m/s,"('time_counter', 'depthu', 'y', 'x')",eORCA1,U,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/U1y/uo_eiv
+tauuo,surface_downward_x_stress,wind stress along i-axis,N/m2,"('time_counter', 'y', 'x')",eORCA1,U,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/U1y/tauuo
+u2o,square_of_sea_water_x_velocity,uu,m/s,"('time_counter', 'depthu', 'y', 'x')",eORCA1,U,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/U1y/u2o
+umo,ocean_mass_x_transport,ocean mass x transport,kg/s,"('time_counter', 'depthu', 'y', 'x')",eORCA1,U,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/U1y/umo
+umo_vint,vertical_integral_of_ocean_mass_x_transport,vertical integral of ocean eulerian mass transport along i-axis,kg/s,"('time_counter', 'y', 'x')",eORCA1,U,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/U1y/umo_vint
+hfx,ocean_heat_x_transport,ocean eulerian heat transport along i-axis,W,"('time_counter', 'y', 'x')",eORCA1,U,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/U1y/hfx
+hfx_adv,advectice_ocean_heat_x_transport,ocean advective heat transport along i-axis,W,"('time_counter', 'y', 'x')",eORCA1,U,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/U1y/hfx_adv
+hfx_diff,ocean_heat_x_transport_due_to_diffusion,ocean diffusion heat transport along i-axis,W,"('time_counter', 'y', 'x')",eORCA1,U,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/U1y/hfx_diff
+sozosatr,ocean_salt_x_transport,ocean eulerian salt transport along i-axis,1e-3*kg/s,"('time_counter', 'y', 'x')",eORCA1,U,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/U1y/sozosatr
+e3v,cell_thickness,v-cell thickness,m,"('time_counter', 'depthv', 'y', 'x')",eORCA1,V,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/V1m/e3v
+vo,sea_water_y_velocity,ocean current along j-axis,m/s,"('time_counter', 'depthv', 'y', 'x')",eORCA1,V,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/V1m/vo
+vo_eiv,bolus_sea_water_y_velocity,eiv ocean current along j-axis,m/s,"('time_counter', 'depthv', 'y', 'x')",eORCA1,V,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/V1m/vo_eiv
+tauvo,surface_downward_y_stress,wind stress along j-axis,N/m2,"('time_counter', 'y', 'x')",eORCA1,V,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/V1m/tauvo
+v2o,square_of_sea_water_y_velocity,vv,m/s,"('time_counter', 'depthv', 'y', 'x')",eORCA1,V,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/V1m/v2o
+vmo,ocean_mass_y_transport,ocean eulerian mass transport along j-axis,kg/s,"('time_counter', 'depthv', 'y', 'x')",eORCA1,V,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/V1m/vmo
+hfy,ocean_heat_y_transport,ocean eulerian heat transport along j-axis,W,"('time_counter', 'y', 'x')",eORCA1,V,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/V1m/hfy
+hfy_adv,advectice_ocean_heat_y_transport,ocean advective heat transport along j-axis,W,"('time_counter', 'y', 'x')",eORCA1,V,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/V1m/hfy_adv
+hfy_diff,ocean_heat_y_transport_due_to_diffusion,ocean diffusion heat transport along j-axis,W,"('time_counter', 'y', 'x')",eORCA1,V,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/V1m/hfy_diff
+somesatr,ocean_salt_y_transport,ocean eulerian salt transport along i-axis,1e-3*kg/s,"('time_counter', 'y', 'x')",eORCA1,V,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/V1m/somesatr
+e3v,cell_thickness,v-cell thickness,m,"('time_counter', 'depthv', 'y', 'x')",eORCA1,V,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/V1y/e3v
+vo,sea_water_y_velocity,ocean current along j-axis,m/s,"('time_counter', 'depthv', 'y', 'x')",eORCA1,V,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/V1y/vo
+vo_eiv,bolus_sea_water_y_velocity,eiv ocean current along j-axis,m/s,"('time_counter', 'depthv', 'y', 'x')",eORCA1,V,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/V1y/vo_eiv
+tauvo,surface_downward_y_stress,wind stress along j-axis,N/m2,"('time_counter', 'y', 'x')",eORCA1,V,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/V1y/tauvo
+v2o,square_of_sea_water_y_velocity,vv,m/s,"('time_counter', 'depthv', 'y', 'x')",eORCA1,V,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/V1y/v2o
+vmo,ocean_mass_y_transport,ocean eulerian mass transport along j-axis,kg/s,"('time_counter', 'depthv', 'y', 'x')",eORCA1,V,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/V1y/vmo
+hfy,ocean_heat_y_transport,ocean eulerian heat transport along j-axis,W,"('time_counter', 'y', 'x')",eORCA1,V,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/V1y/hfy
+hfy_adv,advectice_ocean_heat_y_transport,ocean advective heat transport along j-axis,W,"('time_counter', 'y', 'x')",eORCA1,V,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/V1y/hfy_adv
+hfy_diff,ocean_heat_y_transport_due_to_diffusion,ocean diffusion heat transport along j-axis,W,"('time_counter', 'y', 'x')",eORCA1,V,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/V1y/hfy_diff
+somesatr,ocean_salt_y_transport,ocean eulerian salt transport along i-axis,1e-3*kg/s,"('time_counter', 'y', 'x')",eORCA1,V,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/V1y/somesatr
+e3w,cell_thickness,w-cell thickness,m,"('time_counter', 'depthw', 'y', 'x')",eORCA1,W,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/W1m/e3w
+difvho,ocean_vertical_heat_diffusivity,vertical eddy diffusivity,m2/s,"('time_counter', 'depthw', 'y', 'x')",eORCA1,W,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/W1m/difvho
+difvso,ocean_vertical_salt_diffusivity,salt vertical eddy diffusivity,m2/s,"('time_counter', 'depthw', 'y', 'x')",eORCA1,W,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/W1m/difvso
+difvmo,ocean_vertical_momentum_diffusivity,vertical eddy viscosity,m2/s,"('time_counter', 'depthw', 'y', 'x')",eORCA1,W,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/W1m/difvmo
+avt_evd,enhanced_vertical_heat_diffusivity,convective enhancement of vertical diffusivity,m2/s,"('time_counter', 'depthw', 'y', 'x')",eORCA1,W,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/W1m/avt_evd
+diftrto,ocean_vertical_tracer_diffusivity_due_to_tides,vertical diffusivity due to tidal mixing,m2/s,"('time_counter', 'depthw', 'y', 'x')",eORCA1,W,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/W1m/diftrto
+wmo,upward_ocean_mass_transport,vertical mass transport,kg/s,"('time_counter', 'depthw', 'y', 'x')",eORCA1,W,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/W1m/wmo
+wo,upward_sea_water_velocity,w,m/s,"('time_counter', 'depthw', 'y', 'x')",eORCA1,W,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/W1m/wo
+w2o,square_of_upward_sea_water_velocity,ww,m/s,"('time_counter', 'depthw', 'y', 'x')",eORCA1,W,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/W1m/w2o
+e3w,cell_thickness,w-cell thickness,m,"('time_counter', 'depthw', 'y', 'x')",eORCA1,W,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/W1y/e3w
+difvho,ocean_vertical_heat_diffusivity,vertical eddy diffusivity,m2/s,"('time_counter', 'depthw', 'y', 'x')",eORCA1,W,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/W1y/difvho
+difvso,ocean_vertical_salt_diffusivity,salt vertical eddy diffusivity,m2/s,"('time_counter', 'depthw', 'y', 'x')",eORCA1,W,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/W1y/difvso
+difvmo,ocean_vertical_momentum_diffusivity,vertical eddy viscosity,m2/s,"('time_counter', 'depthw', 'y', 'x')",eORCA1,W,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/W1y/difvmo
+avt_evd,enhanced_vertical_heat_diffusivity,convective enhancement of vertical diffusivity,m2/s,"('time_counter', 'depthw', 'y', 'x')",eORCA1,W,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/W1y/avt_evd
+diftrto,ocean_vertical_tracer_diffusivity_due_to_tides,vertical diffusivity due to tidal mixing,m2/s,"('time_counter', 'depthw', 'y', 'x')",eORCA1,W,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/W1y/diftrto
+wmo,upward_ocean_mass_transport,vertical mass transport,kg/s,"('time_counter', 'depthw', 'y', 'x')",eORCA1,W,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/W1y/wmo
+wo,upward_sea_water_velocity,w,m/s,"('time_counter', 'depthw', 'y', 'x')",eORCA1,W,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/W1y/wo
+w2o,square_of_upward_sea_water_velocity,ww,m/s,"('time_counter', 'depthw', 'y', 'x')",eORCA1,W,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca1-jra55v1/W1y/w2o
+e3t,cell_thickness,t-cell thickness,m,"('time_counter', 'deptht', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/e3t
+thetao_con,sea_water_conservative_temperature,sea_water_conservative_temperature,degC,"('time_counter', 'deptht', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/thetao_con
+so_abs,sea_water_absolute_salinity,sea_water_absolute_salinity,g/kg,"('time_counter', 'deptht', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/so_abs
+zos,sea_surface_height_above_geoid,sea surface height above geoid,m,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/zos
+zossq,square_of_sea_surface_height_above_geoid,square of sea surface height above geoid,m2,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/zossq
+friver,water_flux_into_sea_water_from_rivers,river runoffs,kg/m2/s,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/friver
+hfto,surface_net_downward_total_heat_flux,net downward heat flux,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/hfto
+hfsr,surface_net_downward_solar_heat_flux,shortwave radiation,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/hfsr
+hfns,surface_net_downward_non_solar_heat_flux,non solar downward heat flux,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/hfns
+rsdo,downwelling_shortwave_flux_in_sea_water,shortwave radiation 3d distribution,W/m2,"('time_counter', 'deptht', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/rsdo
+hfds,ocean_surface_downward_total_heat_flux,total flux at ocean surface,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/hfds
+rlntds,ocean_surface_net_downward_longwave_heat_flux,longwave downward heat flux over open ocean,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/rlntds
+hfss,ocean_surface_downward_sensible_heat_flux,sensible downward heat flux over open ocean,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/hfss
+hfls,ocean_surface_downward_latent_heat_flux,latent downward heat flux over open ocean,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/hfls
+hfempds,ocean_surface_downward_heat_flux_from_e-p,downward heat flux from e-p over open ocean,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/hfempds
+rsntds,ocean_surface_net_downward_shortwave_heat_flux,solar heat flux at ocean surface,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/rsntds
+mlotst,ocean_mixed_layer_thickness_defined_by_sigma_theta,ocean mixed layer thickness defined by sigma t,m,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/mlotst
+mlotstsq,square_of_ocean_mixed_layer_thickness_defined_by_sigma_theta,square of ocean mixed layer thickness defined by sigma t,m,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/mlotstsq
+mlotstmax,ocean_mixed_layer_thickness_defined_by_sigma_theta,ocean mixed layer thickness defined by sigma t,m,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/mlotstmax
+mlotstmin,ocean_mixed_layer_thickness_defined_by_sigma_theta,ocean mixed layer thickness defined by sigma t,m,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/mlotstmin
+ficeberg,water_flux_into_sea_water_from_icebergs,icb melt rate of icebergs,kg/m2/s,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/ficeberg
+berg_latent_heat_flux,latent_heat_flux_from_icebergs,icb heat flux to ocean due to melting latent heat,J/m2/s,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/berg_latent_heat_flux
+pbo,sea_water_pressure_at_sea_floor,sea water pressure at sea floor,dbar,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/pbo
+tos_con,sea_surface_temperature,sea_surface_conservative_temperature,degC,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/tos_con
+tossq_con,square_of_sea_surface_temperature,square_of_sea_surface_conservative_temperature,degC2,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/tossq_con
+sos_abs,sea_surface_salinity,sea_surface_absolute_salinity,g/kg,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/sos_abs
+sossq_abs,square_of_sea_surface_salinity,square of sea surface salinity,1e-6,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/sossq_abs
+evs,water_evaporation_flux,water evaporation flux where ice free ocean over sea,kg/m2/s,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/evs
+prsn,snowfall_flux,snowfall flux,kg/m2/s,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/prsn
+hfrainds,temperature_flux_due_to_rain_expressed_as_heat_flux_into_sea_water,temperature flux due to rain expressed as heat flux in to sea water,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/hfrainds
+hfevapds,temperature_flux_due_to_evaporation_expressed_as_heat_flux_out_of_sea_water,temperature flux due to evaporation expressed as heat flux out of sea water,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/hfevapds
+hflx_rnf,temperature_flux_due_to_runoff_expressed_as_heat_flux_into_sea_water,temperature flux due to runoff expressed as heat flux into  sea water,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/hflx_rnf
+sfdsi,downward_sea_ice_basal_salt_flux,downward salt flux,g/m2/s,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/sfdsi
+empmr,water_flux_out_of_sea_ice_and_sea_water,net upward water flux,kg/m2/s,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/empmr
+snowpre,snowfall_flux,snow precipitation,kg/m2/s,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/snowpre
+snow_ai_cea,snowfall_flux,snow over sea-ice (cell average),kg/m2/s,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/snow_ai_cea
+sowaflup,water_flux_out_of_sea_ice_and_sea_water,net upward water flux,kg/m2/s,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/sowaflup
+sosafldo,salt_flux_into_sea_water,downward salt flux,g/m2/s,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/sosafldo
+somixhgt,ocean_mixed_layer_thickness_defined_by_vertical_tracer_diffusivity,turbocline depth (kz = 5e-4),m,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/somixhgt
+somxl010,ocean_mixed_layer_thickness_defined_by_sigma_theta,mixed layer depth (dsigma = 0.01 wrt 10m),m,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/somxl010
+somxzint1,ocean_mixed_layer_thickness_defined_by_sigma_theta,mixed layer depth interpolated,m,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/somxzint1
+soicecov,sea_ice_area_fraction,ice fraction,1,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/soicecov
+sowindsp,wind_speed,wind speed module,m/s,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/sowindsp
+sohflisf,,ice shelf latent heat flux,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/sohflisf
+vohflisf,,ice shelf latent heat flux ( from isf to oce ),W/m2,"('time_counter', 'deptht', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/vohflisf
+sohfcisf,,ice shelf heat content flux,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/sohfcisf
+vohfcisf,,ice shelf heat content flux of injected water ( from isf to oce ),W/m2,"('time_counter', 'deptht', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/vohfcisf
+sowflisf,,ice shelf melting,kg/m2/s,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/sowflisf
+vowflisf,,3d ice shelf fresh water flux ( from isf to oce ),kg/m2/s,"('time_counter', 'deptht', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/vowflisf
+ocontempmint,integral_wrt_depth_of_product_of_density_and_conservative_temperature,vertical integral of conservative temperature times density,(kg m2) degree_C,"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/ocontempmint
+somint_abs,integral_wrt_depth_of_product_of_density_and_absolute_salinity,vertical integral of absolute salinity times density,(kg m2) x (1e-3),"('time_counter', 'y', 'x')",eORCA025,T,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T5d/somint_abs
+e3t,cell_thickness,t-cell thickness,m,"('time_counter', 'deptht', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/e3t
+thetao_con,sea_water_conservative_temperature,sea_water_conservative_temperature,degC,"('time_counter', 'deptht', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/thetao_con
+so_abs,sea_water_absolute_salinity,sea_water_absolute_salinity,g/kg,"('time_counter', 'deptht', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/so_abs
+zos,sea_surface_height_above_geoid,sea surface height above geoid,m,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/zos
+zossq,square_of_sea_surface_height_above_geoid,square of sea surface height above geoid,m2,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/zossq
+friver,water_flux_into_sea_water_from_rivers,river runoffs,kg/m2/s,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/friver
+hfto,surface_net_downward_total_heat_flux,net downward heat flux,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/hfto
+hfsr,surface_net_downward_solar_heat_flux,shortwave radiation,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/hfsr
+hfns,surface_net_downward_non_solar_heat_flux,non solar downward heat flux,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/hfns
+rsdo,downwelling_shortwave_flux_in_sea_water,shortwave radiation 3d distribution,W/m2,"('time_counter', 'deptht', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/rsdo
+hfds,ocean_surface_downward_total_heat_flux,total flux at ocean surface,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/hfds
+rlntds,ocean_surface_net_downward_longwave_heat_flux,longwave downward heat flux over open ocean,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/rlntds
+hfss,ocean_surface_downward_sensible_heat_flux,sensible downward heat flux over open ocean,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/hfss
+hfls,ocean_surface_downward_latent_heat_flux,latent downward heat flux over open ocean,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/hfls
+hfempds,ocean_surface_downward_heat_flux_from_e-p,downward heat flux from e-p over open ocean,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/hfempds
+rsntds,ocean_surface_net_downward_shortwave_heat_flux,solar heat flux at ocean surface,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/rsntds
+mlotst,ocean_mixed_layer_thickness_defined_by_sigma_theta,ocean mixed layer thickness defined by sigma t,m,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/mlotst
+mlotstsq,square_of_ocean_mixed_layer_thickness_defined_by_sigma_theta,square of ocean mixed layer thickness defined by sigma t,m,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/mlotstsq
+mlotstmax,ocean_mixed_layer_thickness_defined_by_sigma_theta,ocean mixed layer thickness defined by sigma t,m,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/mlotstmax
+mlotstmin,ocean_mixed_layer_thickness_defined_by_sigma_theta,ocean mixed layer thickness defined by sigma t,m,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/mlotstmin
+ficeberg,water_flux_into_sea_water_from_icebergs,icb melt rate of icebergs,kg/m2/s,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/ficeberg
+berg_latent_heat_flux,latent_heat_flux_from_icebergs,icb heat flux to ocean due to melting latent heat,J/m2/s,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/berg_latent_heat_flux
+pbo,sea_water_pressure_at_sea_floor,sea water pressure at sea floor,dbar,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/pbo
+tos_con,sea_surface_temperature,sea_surface_conservative_temperature,degC,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/tos_con
+tossq_con,square_of_sea_surface_temperature,square_of_sea_surface_conservative_temperature,degC2,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/tossq_con
+sos_abs,sea_surface_salinity,sea_surface_absolute_salinity,g/kg,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/sos_abs
+sossq_abs,square_of_sea_surface_salinity,square of sea surface salinity,1e-6,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/sossq_abs
+evs,water_evaporation_flux,water evaporation flux where ice free ocean over sea,kg/m2/s,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/evs
+prsn,snowfall_flux,snowfall flux,kg/m2/s,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/prsn
+hfrainds,temperature_flux_due_to_rain_expressed_as_heat_flux_into_sea_water,temperature flux due to rain expressed as heat flux in to sea water,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/hfrainds
+hfevapds,temperature_flux_due_to_evaporation_expressed_as_heat_flux_out_of_sea_water,temperature flux due to evaporation expressed as heat flux out of sea water,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/hfevapds
+hflx_rnf,temperature_flux_due_to_runoff_expressed_as_heat_flux_into_sea_water,temperature flux due to runoff expressed as heat flux into  sea water,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/hflx_rnf
+sfdsi,downward_sea_ice_basal_salt_flux,downward salt flux,g/m2/s,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/sfdsi
+empmr,water_flux_out_of_sea_ice_and_sea_water,net upward water flux,kg/m2/s,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/empmr
+snowpre,snowfall_flux,snow precipitation,kg/m2/s,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/snowpre
+snow_ai_cea,snowfall_flux,snow over sea-ice (cell average),kg/m2/s,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/snow_ai_cea
+sowaflup,water_flux_out_of_sea_ice_and_sea_water,net upward water flux,kg/m2/s,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/sowaflup
+sosafldo,salt_flux_into_sea_water,downward salt flux,g/m2/s,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/sosafldo
+somixhgt,ocean_mixed_layer_thickness_defined_by_vertical_tracer_diffusivity,turbocline depth (kz = 5e-4),m,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/somixhgt
+somxl010,ocean_mixed_layer_thickness_defined_by_sigma_theta,mixed layer depth (dsigma = 0.01 wrt 10m),m,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/somxl010
+somxzint1,ocean_mixed_layer_thickness_defined_by_sigma_theta,mixed layer depth interpolated,m,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/somxzint1
+soicecov,sea_ice_area_fraction,ice fraction,1,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/soicecov
+sowindsp,wind_speed,wind speed module,m/s,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/sowindsp
+sohflisf,,ice shelf latent heat flux,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/sohflisf
+vohflisf,,ice shelf latent heat flux ( from isf to oce ),W/m2,"('time_counter', 'deptht', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/vohflisf
+sohfcisf,,ice shelf heat content flux,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/sohfcisf
+vohfcisf,,ice shelf heat content flux of injected water ( from isf to oce ),W/m2,"('time_counter', 'deptht', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/vohfcisf
+sowflisf,,ice shelf melting,kg/m2/s,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/sowflisf
+vowflisf,,3d ice shelf fresh water flux ( from isf to oce ),kg/m2/s,"('time_counter', 'deptht', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/vowflisf
+ocontempmint,integral_wrt_depth_of_product_of_density_and_conservative_temperature,vertical integral of conservative temperature times density,(kg m2) degree_C,"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/ocontempmint
+somint_abs,integral_wrt_depth_of_product_of_density_and_absolute_salinity,vertical integral of absolute salinity times density,(kg m2) x (1e-3),"('time_counter', 'y', 'x')",eORCA025,T,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1m/somint_abs
+e3t,cell_thickness,t-cell thickness,m,"('time_counter', 'deptht', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/e3t
+thetao_con,sea_water_conservative_temperature,sea_water_conservative_temperature,degC,"('time_counter', 'deptht', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/thetao_con
+so_abs,sea_water_absolute_salinity,sea_water_absolute_salinity,g/kg,"('time_counter', 'deptht', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/so_abs
+zos,sea_surface_height_above_geoid,sea surface height above geoid,m,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/zos
+zossq,square_of_sea_surface_height_above_geoid,square of sea surface height above geoid,m2,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/zossq
+friver,water_flux_into_sea_water_from_rivers,river runoffs,kg/m2/s,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/friver
+hfto,surface_net_downward_total_heat_flux,net downward heat flux,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/hfto
+hfsr,surface_net_downward_solar_heat_flux,shortwave radiation,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/hfsr
+hfns,surface_net_downward_non_solar_heat_flux,non solar downward heat flux,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/hfns
+rsdo,downwelling_shortwave_flux_in_sea_water,shortwave radiation 3d distribution,W/m2,"('time_counter', 'deptht', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/rsdo
+hfds,ocean_surface_downward_total_heat_flux,total flux at ocean surface,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/hfds
+rlntds,ocean_surface_net_downward_longwave_heat_flux,longwave downward heat flux over open ocean,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/rlntds
+hfss,ocean_surface_downward_sensible_heat_flux,sensible downward heat flux over open ocean,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/hfss
+hfls,ocean_surface_downward_latent_heat_flux,latent downward heat flux over open ocean,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/hfls
+hfempds,ocean_surface_downward_heat_flux_from_e-p,downward heat flux from e-p over open ocean,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/hfempds
+rsntds,ocean_surface_net_downward_shortwave_heat_flux,solar heat flux at ocean surface,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/rsntds
+mlotst,ocean_mixed_layer_thickness_defined_by_sigma_theta,ocean mixed layer thickness defined by sigma t,m,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/mlotst
+mlotstsq,square_of_ocean_mixed_layer_thickness_defined_by_sigma_theta,square of ocean mixed layer thickness defined by sigma t,m,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/mlotstsq
+mlotstmax,ocean_mixed_layer_thickness_defined_by_sigma_theta,ocean mixed layer thickness defined by sigma t,m,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/mlotstmax
+mlotstmin,ocean_mixed_layer_thickness_defined_by_sigma_theta,ocean mixed layer thickness defined by sigma t,m,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/mlotstmin
+ficeberg,water_flux_into_sea_water_from_icebergs,icb melt rate of icebergs,kg/m2/s,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/ficeberg
+berg_latent_heat_flux,latent_heat_flux_from_icebergs,icb heat flux to ocean due to melting latent heat,J/m2/s,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/berg_latent_heat_flux
+pbo,sea_water_pressure_at_sea_floor,sea water pressure at sea floor,dbar,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/pbo
+tos_con,sea_surface_temperature,sea_surface_conservative_temperature,degC,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/tos_con
+tossq_con,square_of_sea_surface_temperature,square_of_sea_surface_conservative_temperature,degC2,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/tossq_con
+sos_abs,sea_surface_salinity,sea_surface_absolute_salinity,g/kg,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/sos_abs
+sossq_abs,square_of_sea_surface_salinity,square of sea surface salinity,1e-6,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/sossq_abs
+evs,water_evaporation_flux,water evaporation flux where ice free ocean over sea,kg/m2/s,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/evs
+prsn,snowfall_flux,snowfall flux,kg/m2/s,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/prsn
+hfrainds,temperature_flux_due_to_rain_expressed_as_heat_flux_into_sea_water,temperature flux due to rain expressed as heat flux in to sea water,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/hfrainds
+hfevapds,temperature_flux_due_to_evaporation_expressed_as_heat_flux_out_of_sea_water,temperature flux due to evaporation expressed as heat flux out of sea water,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/hfevapds
+hflx_rnf,temperature_flux_due_to_runoff_expressed_as_heat_flux_into_sea_water,temperature flux due to runoff expressed as heat flux into  sea water,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/hflx_rnf
+sfdsi,downward_sea_ice_basal_salt_flux,downward salt flux,g/m2/s,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/sfdsi
+empmr,water_flux_out_of_sea_ice_and_sea_water,net upward water flux,kg/m2/s,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/empmr
+snowpre,snowfall_flux,snow precipitation,kg/m2/s,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/snowpre
+snow_ai_cea,snowfall_flux,snow over sea-ice (cell average),kg/m2/s,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/snow_ai_cea
+sowaflup,water_flux_out_of_sea_ice_and_sea_water,net upward water flux,kg/m2/s,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/sowaflup
+sosafldo,salt_flux_into_sea_water,downward salt flux,g/m2/s,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/sosafldo
+somixhgt,ocean_mixed_layer_thickness_defined_by_vertical_tracer_diffusivity,turbocline depth (kz = 5e-4),m,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/somixhgt
+somxl010,ocean_mixed_layer_thickness_defined_by_sigma_theta,mixed layer depth (dsigma = 0.01 wrt 10m),m,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/somxl010
+somxzint1,ocean_mixed_layer_thickness_defined_by_sigma_theta,mixed layer depth interpolated,m,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/somxzint1
+soicecov,sea_ice_area_fraction,ice fraction,1,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/soicecov
+sowindsp,wind_speed,wind speed module,m/s,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/sowindsp
+sohflisf,,ice shelf latent heat flux,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/sohflisf
+vohflisf,,ice shelf latent heat flux ( from isf to oce ),W/m2,"('time_counter', 'deptht', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/vohflisf
+sohfcisf,,ice shelf heat content flux,W/m2,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/sohfcisf
+vohfcisf,,ice shelf heat content flux of injected water ( from isf to oce ),W/m2,"('time_counter', 'deptht', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/vohfcisf
+sowflisf,,ice shelf melting,kg/m2/s,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/sowflisf
+vowflisf,,3d ice shelf fresh water flux ( from isf to oce ),kg/m2/s,"('time_counter', 'deptht', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/vowflisf
+ocontempmint,integral_wrt_depth_of_product_of_density_and_conservative_temperature,vertical integral of conservative temperature times density,(kg m2) degree_C,"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/ocontempmint
+somint_abs,integral_wrt_depth_of_product_of_density_and_absolute_salinity,vertical integral of absolute salinity times density,(kg m2) x (1e-3),"('time_counter', 'y', 'x')",eORCA025,T,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/T1y/somint_abs
+e3u,cell_thickness,u-cell thickness,m,"('time_counter', 'depthu', 'y', 'x')",eORCA025,U,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/U5d/e3u
+uo,sea_water_x_velocity,ocean current along i-axis,m/s,"('time_counter', 'depthu', 'y', 'x')",eORCA025,U,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/U5d/uo
+uo_eiv,bolus_sea_water_x_velocity,eiv ocean current along i-axis,m/s,"('time_counter', 'depthu', 'y', 'x')",eORCA025,U,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/U5d/uo_eiv
+tauuo,surface_downward_x_stress,wind stress along i-axis,N/m2,"('time_counter', 'y', 'x')",eORCA025,U,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/U5d/tauuo
+u2o,square_of_sea_water_x_velocity,uu,m/s,"('time_counter', 'depthu', 'y', 'x')",eORCA025,U,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/U5d/u2o
+umo,ocean_mass_x_transport,ocean mass x transport,kg/s,"('time_counter', 'depthu', 'y', 'x')",eORCA025,U,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/U5d/umo
+umo_vint,vertical_integral_of_ocean_mass_x_transport,vertical integral of ocean eulerian mass transport along i-axis,kg/s,"('time_counter', 'y', 'x')",eORCA025,U,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/U5d/umo_vint
+sozosatr,ocean_salt_x_transport,ocean eulerian salt transport along i-axis,1e-3*kg/s,"('time_counter', 'y', 'x')",eORCA025,U,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/U5d/sozosatr
+e3u,cell_thickness,u-cell thickness,m,"('time_counter', 'depthu', 'y', 'x')",eORCA025,U,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/U1m/e3u
+uo,sea_water_x_velocity,ocean current along i-axis,m/s,"('time_counter', 'depthu', 'y', 'x')",eORCA025,U,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/U1m/uo
+uo_eiv,bolus_sea_water_x_velocity,eiv ocean current along i-axis,m/s,"('time_counter', 'depthu', 'y', 'x')",eORCA025,U,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/U1m/uo_eiv
+tauuo,surface_downward_x_stress,wind stress along i-axis,N/m2,"('time_counter', 'y', 'x')",eORCA025,U,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/U1m/tauuo
+u2o,square_of_sea_water_x_velocity,uu,m/s,"('time_counter', 'depthu', 'y', 'x')",eORCA025,U,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/U1m/u2o
+umo,ocean_mass_x_transport,ocean mass x transport,kg/s,"('time_counter', 'depthu', 'y', 'x')",eORCA025,U,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/U1m/umo
+umo_vint,vertical_integral_of_ocean_mass_x_transport,vertical integral of ocean eulerian mass transport along i-axis,kg/s,"('time_counter', 'y', 'x')",eORCA025,U,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/U1m/umo_vint
+hfx,ocean_heat_x_transport,ocean eulerian heat transport along i-axis,W,"('time_counter', 'y', 'x')",eORCA025,U,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/U1m/hfx
+hfx_adv,advectice_ocean_heat_x_transport,ocean advective heat transport along i-axis,W,"('time_counter', 'y', 'x')",eORCA025,U,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/U1m/hfx_adv
+hfx_diff,ocean_heat_x_transport_due_to_diffusion,ocean diffusion heat transport along i-axis,W,"('time_counter', 'y', 'x')",eORCA025,U,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/U1m/hfx_diff
+sozosatr,ocean_salt_x_transport,ocean eulerian salt transport along i-axis,1e-3*kg/s,"('time_counter', 'y', 'x')",eORCA025,U,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/U1m/sozosatr
+e3u,cell_thickness,u-cell thickness,m,"('time_counter', 'depthu', 'y', 'x')",eORCA025,U,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/U1y/e3u
+uo,sea_water_x_velocity,ocean current along i-axis,m/s,"('time_counter', 'depthu', 'y', 'x')",eORCA025,U,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/U1y/uo
+uo_eiv,bolus_sea_water_x_velocity,eiv ocean current along i-axis,m/s,"('time_counter', 'depthu', 'y', 'x')",eORCA025,U,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/U1y/uo_eiv
+tauuo,surface_downward_x_stress,wind stress along i-axis,N/m2,"('time_counter', 'y', 'x')",eORCA025,U,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/U1y/tauuo
+u2o,square_of_sea_water_x_velocity,uu,m/s,"('time_counter', 'depthu', 'y', 'x')",eORCA025,U,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/U1y/u2o
+umo,ocean_mass_x_transport,ocean mass x transport,kg/s,"('time_counter', 'depthu', 'y', 'x')",eORCA025,U,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/U1y/umo
+umo_vint,vertical_integral_of_ocean_mass_x_transport,vertical integral of ocean eulerian mass transport along i-axis,kg/s,"('time_counter', 'y', 'x')",eORCA025,U,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/U1y/umo_vint
+hfx,ocean_heat_x_transport,ocean eulerian heat transport along i-axis,W,"('time_counter', 'y', 'x')",eORCA025,U,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/U1y/hfx
+hfx_adv,advectice_ocean_heat_x_transport,ocean advective heat transport along i-axis,W,"('time_counter', 'y', 'x')",eORCA025,U,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/U1y/hfx_adv
+hfx_diff,ocean_heat_x_transport_due_to_diffusion,ocean diffusion heat transport along i-axis,W,"('time_counter', 'y', 'x')",eORCA025,U,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/U1y/hfx_diff
+sozosatr,ocean_salt_x_transport,ocean eulerian salt transport along i-axis,1e-3*kg/s,"('time_counter', 'y', 'x')",eORCA025,U,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/U1y/sozosatr
+e3v,cell_thickness,v-cell thickness,m,"('time_counter', 'depthv', 'y', 'x')",eORCA025,V,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/V5d/e3v
+vo,sea_water_y_velocity,ocean current along j-axis,m/s,"('time_counter', 'depthv', 'y', 'x')",eORCA025,V,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/V5d/vo
+vo_eiv,bolus_sea_water_y_velocity,eiv ocean current along j-axis,m/s,"('time_counter', 'depthv', 'y', 'x')",eORCA025,V,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/V5d/vo_eiv
+tauvo,surface_downward_y_stress,wind stress along j-axis,N/m2,"('time_counter', 'y', 'x')",eORCA025,V,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/V5d/tauvo
+v2o,square_of_sea_water_y_velocity,vv,m/s,"('time_counter', 'depthv', 'y', 'x')",eORCA025,V,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/V5d/v2o
+vmo,ocean_mass_y_transport,ocean eulerian mass transport along j-axis,kg/s,"('time_counter', 'depthv', 'y', 'x')",eORCA025,V,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/V5d/vmo
+somesatr,ocean_salt_y_transport,ocean eulerian salt transport along i-axis,1e-3*kg/s,"('time_counter', 'y', 'x')",eORCA025,V,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/V5d/somesatr
+e3v,cell_thickness,v-cell thickness,m,"('time_counter', 'depthv', 'y', 'x')",eORCA025,V,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/V1m/e3v
+vo,sea_water_y_velocity,ocean current along j-axis,m/s,"('time_counter', 'depthv', 'y', 'x')",eORCA025,V,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/V1m/vo
+vo_eiv,bolus_sea_water_y_velocity,eiv ocean current along j-axis,m/s,"('time_counter', 'depthv', 'y', 'x')",eORCA025,V,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/V1m/vo_eiv
+tauvo,surface_downward_y_stress,wind stress along j-axis,N/m2,"('time_counter', 'y', 'x')",eORCA025,V,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/V1m/tauvo
+v2o,square_of_sea_water_y_velocity,vv,m/s,"('time_counter', 'depthv', 'y', 'x')",eORCA025,V,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/V1m/v2o
+vmo,ocean_mass_y_transport,ocean eulerian mass transport along j-axis,kg/s,"('time_counter', 'depthv', 'y', 'x')",eORCA025,V,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/V1m/vmo
+hfy,ocean_heat_y_transport,ocean eulerian heat transport along j-axis,W,"('time_counter', 'y', 'x')",eORCA025,V,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/V1m/hfy
+hfy_adv,advectice_ocean_heat_y_transport,ocean advective heat transport along j-axis,W,"('time_counter', 'y', 'x')",eORCA025,V,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/V1m/hfy_adv
+hfy_diff,ocean_heat_y_transport_due_to_diffusion,ocean diffusion heat transport along j-axis,W,"('time_counter', 'y', 'x')",eORCA025,V,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/V1m/hfy_diff
+somesatr,ocean_salt_y_transport,ocean eulerian salt transport along i-axis,1e-3*kg/s,"('time_counter', 'y', 'x')",eORCA025,V,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/V1m/somesatr
+e3v,cell_thickness,v-cell thickness,m,"('time_counter', 'depthv', 'y', 'x')",eORCA025,V,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/V1y/e3v
+vo,sea_water_y_velocity,ocean current along j-axis,m/s,"('time_counter', 'depthv', 'y', 'x')",eORCA025,V,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/V1y/vo
+vo_eiv,bolus_sea_water_y_velocity,eiv ocean current along j-axis,m/s,"('time_counter', 'depthv', 'y', 'x')",eORCA025,V,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/V1y/vo_eiv
+tauvo,surface_downward_y_stress,wind stress along j-axis,N/m2,"('time_counter', 'y', 'x')",eORCA025,V,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/V1y/tauvo
+v2o,square_of_sea_water_y_velocity,vv,m/s,"('time_counter', 'depthv', 'y', 'x')",eORCA025,V,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/V1y/v2o
+vmo,ocean_mass_y_transport,ocean eulerian mass transport along j-axis,kg/s,"('time_counter', 'depthv', 'y', 'x')",eORCA025,V,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/V1y/vmo
+hfy,ocean_heat_y_transport,ocean eulerian heat transport along j-axis,W,"('time_counter', 'y', 'x')",eORCA025,V,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/V1y/hfy
+hfy_adv,advectice_ocean_heat_y_transport,ocean advective heat transport along j-axis,W,"('time_counter', 'y', 'x')",eORCA025,V,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/V1y/hfy_adv
+hfy_diff,ocean_heat_y_transport_due_to_diffusion,ocean diffusion heat transport along j-axis,W,"('time_counter', 'y', 'x')",eORCA025,V,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/V1y/hfy_diff
+somesatr,ocean_salt_y_transport,ocean eulerian salt transport along i-axis,1e-3*kg/s,"('time_counter', 'y', 'x')",eORCA025,V,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/V1y/somesatr
+e3w,cell_thickness,w-cell thickness,m,"('time_counter', 'depthw', 'y', 'x')",eORCA025,W,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/W5d/e3w
+wmo,upward_ocean_mass_transport,vertical mass transport,kg/s,"('time_counter', 'depthw', 'y', 'x')",eORCA025,W,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/W5d/wmo
+wo,upward_sea_water_velocity,w,m/s,"('time_counter', 'depthw', 'y', 'x')",eORCA025,W,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/W5d/wo
+w2o,square_of_upward_sea_water_velocity,ww,m/s,"('time_counter', 'depthw', 'y', 'x')",eORCA025,W,5d,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/W5d/w2o
+e3w,cell_thickness,w-cell thickness,m,"('time_counter', 'depthw', 'y', 'x')",eORCA025,W,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/W1m/e3w
+difvho,ocean_vertical_heat_diffusivity,vertical eddy diffusivity,m2/s,"('time_counter', 'depthw', 'y', 'x')",eORCA025,W,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/W1m/difvho
+difvso,ocean_vertical_salt_diffusivity,salt vertical eddy diffusivity,m2/s,"('time_counter', 'depthw', 'y', 'x')",eORCA025,W,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/W1m/difvso
+difvmo,ocean_vertical_momentum_diffusivity,vertical eddy viscosity,m2/s,"('time_counter', 'depthw', 'y', 'x')",eORCA025,W,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/W1m/difvmo
+avt_evd,enhanced_vertical_heat_diffusivity,convective enhancement of vertical diffusivity,m2/s,"('time_counter', 'depthw', 'y', 'x')",eORCA025,W,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/W1m/avt_evd
+diftrto,ocean_vertical_tracer_diffusivity_due_to_tides,vertical diffusivity due to tidal mixing,m2/s,"('time_counter', 'depthw', 'y', 'x')",eORCA025,W,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/W1m/diftrto
+wmo,upward_ocean_mass_transport,vertical mass transport,kg/s,"('time_counter', 'depthw', 'y', 'x')",eORCA025,W,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/W1m/wmo
+wo,upward_sea_water_velocity,w,m/s,"('time_counter', 'depthw', 'y', 'x')",eORCA025,W,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/W1m/wo
+w2o,square_of_upward_sea_water_velocity,ww,m/s,"('time_counter', 'depthw', 'y', 'x')",eORCA025,W,1m,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/W1m/w2o
+e3w,cell_thickness,w-cell thickness,m,"('time_counter', 'depthw', 'y', 'x')",eORCA025,W,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/W1y/e3w
+difvho,ocean_vertical_heat_diffusivity,vertical eddy diffusivity,m2/s,"('time_counter', 'depthw', 'y', 'x')",eORCA025,W,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/W1y/difvho
+difvso,ocean_vertical_salt_diffusivity,salt vertical eddy diffusivity,m2/s,"('time_counter', 'depthw', 'y', 'x')",eORCA025,W,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/W1y/difvso
+difvmo,ocean_vertical_momentum_diffusivity,vertical eddy viscosity,m2/s,"('time_counter', 'depthw', 'y', 'x')",eORCA025,W,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/W1y/difvmo
+avt_evd,enhanced_vertical_heat_diffusivity,convective enhancement of vertical diffusivity,m2/s,"('time_counter', 'depthw', 'y', 'x')",eORCA025,W,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/W1y/avt_evd
+diftrto,ocean_vertical_tracer_diffusivity_due_to_tides,vertical diffusivity due to tidal mixing,m2/s,"('time_counter', 'depthw', 'y', 'x')",eORCA025,W,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/W1y/diftrto
+wmo,upward_ocean_mass_transport,vertical mass transport,kg/s,"('time_counter', 'depthw', 'y', 'x')",eORCA025,W,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/W1y/wmo
+wo,upward_sea_water_velocity,w,m/s,"('time_counter', 'depthw', 'y', 'x')",eORCA025,W,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/W1y/wo
+w2o,square_of_upward_sea_water_velocity,ww,m/s,"('time_counter', 'depthw', 'y', 'x')",eORCA025,W,1y,https://noc-msm-o.s3-ext.jc.rl.ac.uk/npd-eorca025-jra55v1/W1y/w2o


### PR DESCRIPTION
Added SLURM run scripts used to transfer eORCA1 & eORCA025 NPD (5d, 1m, 1y) outputs to the JASMIN Object Store from the Anemone HPC. Outputs variables time series will be stored as individual .zarr stores.

- [ ] eORCA1 + eORCA025 ancillary files.
- [ ] eORCA1 + eORCA025 monthly mean output files (e.g., T1m, U1m, V1m etc.).
- [ ] eORCA1 + eORCA025 annual mean output files (e.g., T1y, U1y, V1y etc.)
- [ ] eORCA025 5-day mean output files (e.g., T5d, U5d, V5d etc.)
- [ ] eORCA1 + eORCA025 monthly mean diagnostics (e.g., RAPID, MOVE, SAMBA in M1m).

Added NPD v1 Intake catalog & variable inventory.

- [ ] Added script to create variable inventory for NPD v1.
- [ ] Added NPD v1 catalog for eORCA1 & eORCA025 5d, 1m, 1y fields on JASMIN OS.
- [ ] Added variable inventory .csv file.
