### PR TITLE
Update ci.yml workflow to fix bugs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.x
+          python-version: 3.12
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
       - uses: actions/cache@v4
         with:
@@ -25,6 +25,6 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: pip install mkdocs-material mkdocs-glightbox mkdocs-marimo mkdocs-jupyter pandas marimo
+      - run: pip install mkdocs-material mkdocs-glightbox mkdocs-marimo mkdocs-jupyter pandas marimo==0.11.2
       - working-directory: ./docs
         run: mkdocs gh-deploy --force


### PR DESCRIPTION
Updated python version to 3.12 (> v3.12 does not include cgi package in standard library).

Updated marimo version for pip installation (bug found in mo.ui.table in v0.11.3).