### PR TITLE
add namelist_cfg_ERA5_se

### DIFF
--- a/cfgs/GLOBAL_QCO/eORCA025/namelist_cfg_ERA5_se
+++ b/cfgs/GLOBAL_QCO/eORCA025/namelist_cfg_ERA5_se
@@ -1,0 +1,297 @@
+! Created by: print_concise_namelist_cfg -c ./namelist_cfg -r ./namelist_ref -overwrite False
+
+&namrun
+    cn_exp = 'eORCA025-se',
+        nn_it000 = CHANGEME,
+        nn_itend = CHANGEME,
+    nn_date0 = 19760101,
+        ln_rstart = CHANGEME,
+        ln_reset_ts=.false.,
+    nn_leapy = 1,
+    nn_rstctl = 2,
+        cn_ocerst_in = 'CHANGEME',
+    cn_ocerst_indir = './RESTARTS',
+    cn_ocerst_outdir = './RESTARTS',
+    nn_stock = 70128,
+    ln_mskland = .true.,
+    ln_rst_list = .false.
+    nn_stocklist = 0,0,0,0,0,0,0,0,0,0
+/
+
+&namdom
+    rn_Dt = 600.0,
+    rn_atfp = 0.05,
+    ln_meshmask = .false.,
+/
+
+&namcfg
+    ln_read_cfg = .true.,
+    cn_domcfg = './INPUT/domcfg-se.nc',
+    ln_closea    = .true.,
+/
+
+&namclo
+   ln_maskcs = .true.,
+/
+
+&namtsd
+    cn_dir = './INPUT/',
+        ln_tsd_init = .true.,
+        ln_tsd_interp=.true.,
+    sn_tem = 'woa23_decav71A0_TS_TEOS10_eORCA025.nc', -1, 'temperature', .true., .true., 'yearly',
+             '', '', ''
+    sn_sal = 'woa23_decav71A0_TS_TEOS10_eORCA025.nc', -1, 'salinity', .true., .true., 'yearly',
+             '', '', ''
+    sn_dep  = 'woa23_depth_mask.nc' ,                                -12, 'depth_4D',   .false.   , .true.  , 'yearly',
+             '' ,    ''    ,  ''
+    sn_msk  = 'woa23_depth_mask.nc' ,                                -12, 'mask'    ,   .false.   , .true.  , 'yearly',
+             '' ,    ''    ,  ''
+/
+
+&namsbc
+    nn_fsbc = 1,
+    ln_blk = .true.,
+    nn_ice = 2,
+    ln_traqsr = .true.,
+    ln_ssr = .true.,
+    ln_rnf = .true.,
+    nn_fwb = 1,
+/
+
+&namsbc_blk
+    ln_NCAR      = .false.,  ! "NCAR"      algorithm   (Large and Yeager 2008)
+    ln_ECMWF     = .true.,   ! "ECMWF"     algorithm   (IFS cycle 45r1)
+       rn_zqt       = 2.,    !  Air temperature & humidity reference height (m)
+    ln_humi_sph  = .false.,  !  humidity "sn_humi" is specific humidity  [kg/kg]
+    ln_humi_dpt  = .true.,   !  humidity "sn_humi" is dew-point temperature [K]
+    ln_crt_fbk = .false.,    !  Add surface current feedback to the wind stress (Renault et al. 2020, doi: 10.1029/2019MS001715)
+       rn_stau_a = -2.9e-3   !     Alpha from eq. 10: Stau = Alpha * Wnd + Beta
+       rn_stau_b =  8.0e-3   !     Beta
+    cn_dir = './INPUT/ERA5_t2m_adj/',
+    sn_humi    = 'd2m',      1, 'd2m',      .true.,  .false., 'monthly', 'weights_ERA5_eORCA025_bilin.nc', '', ''
+    sn_prec    = 'mtpr',     1, 'mtpr',     .true.,  .false., 'monthly', 'weights_ERA5_eORCA025_bilin.nc', '', ''
+    sn_qlw     = 'msdwlwrf', 1, 'msdwlwrf', .false., .false., 'monthly', 'weights_ERA5_eORCA025_bilin.nc', '', ''
+    sn_qsr     = 'msdwswrf', 1, 'msdwswrf', .false., .false., 'monthly', 'weights_ERA5_eORCA025_bilin.nc', '', ''
+    sn_slp     = 'msl',      1, 'msl',      .true.,  .false., 'monthly', 'weights_ERA5_eORCA025_bilin.nc', '', ''
+    sn_snow    = 'msr',      1, 'msr',      .true.,  .false., 'monthly', 'weights_ERA5_eORCA025_bilin.nc', '', ''
+    sn_tair    = 't2m',      1, 't2m',      .true.,  .false., 'monthly', 'weights_ERA5_eORCA025_bilin.nc', '', ''
+    sn_wndi    = 'u10',      1, 'u10',      .true.,  .false., 'monthly', 'weights_ERA5_eORCA025_bicub.nc', 'Ume', ''
+    sn_wndj    = 'v10',      1, 'v10',      .true.,  .false., 'monthly', 'weights_ERA5_eORCA025_bicub.nc', 'Vme', ''
+/
+
+&namtra_qsr
+    sn_chl = 'merged_ESACCI_BIOMER4V1R1_CHL_REG05', -1, 'CHLA', .true.,
+             .true., 'yearly', 'weights_REG05_to_ORCA025_bilin.nc', '',
+             '',
+    cn_dir = './INPUT/',
+    ln_qsr_rgb = .true.,
+    nn_chldta = 1,
+/
+
+&namsbc_ssr
+    nn_sssr = 2,
+    rn_deds = -33.3333333,
+    cn_dir = './INPUT/',
+    sn_sss = 'woa23_decav91C0_sss_TEOS10_eORCA025.nc', -1, 'salinity', .true., .true., 'yearly',
+             '', '', '',
+/
+
+&namsbc_rnf
+    cn_dir = './INPUT/',
+    sn_rnf = 'eORCA025_runoff_GO6_icb.nc', -1, 'sornficb', .true., .true.,
+             'yearly', '', '', '',
+    sn_cnf = 'eORCA025_runoff_GO6_icb.nc', 0, 'socoefr', .false., .true.,
+             'yearly', '', '', '',
+    sn_t_rnf='eORCA025_runoff_GO6_icb.nc',-12,'icbrnftemper',.false.,.true.,'yearly','','',''
+    ln_rnf_mouth = .true.,
+    ln_rnf_tem   = .true.,
+    rn_hrnf = 10.0,
+    rn_avt_rnf = 0.002,
+    rn_rnf_max = 0.05,
+/
+
+&namisf
+    ln_isf = .true.,
+    ln_isfpar_mlt = .true.,
+    sn_isfpar_fwf = 'INPUT/eORCA025_runoff_GO6_icb.nc', -1, 'sofwfisf', .false.,
+                    .true., 'yearly', '', '', '',
+    sn_isfpar_zmax = 'INPUT/eORCA025_runoff_GO6_icb.nc', -12, 'sozisfmax', .false.,
+                     .true., 'yearly', '', '', '',
+    sn_isfpar_zmin = 'INPUT/eORCA025_runoff_GO6_icb.nc', -12, 'sozisfmin', .false.,
+                     .true., 'yearly', '', '', '',
+/
+
+&namlbc
+    cn_shlat2d_file='shlat2d.nc',
+    cn_shlat2d_var='shlat2d',
+    ln_shlat2d=.true.,
+    rn_shlat = 0.0,
+/
+
+&nam_tide
+    ln_tide     = .true.,
+      nn_tide_var   = 1
+      ln_tide_dia   = .true.,
+      ln_tide_pot   = .true.,
+         rn_tide_gamma = 0.7
+         ln_scal_load  = .true.,
+            rn_scal_load = 0.12
+      ln_tide_ramp  = .true.,
+         rn_tide_ramp_dt = 28.
+
+!     ln_int_wave_drag = .true.,
+!     ln_calc_tdiss = .false.,   ! calculate tdiss rather than reading in
+!        cn_int_wave_drag = 'INPUTS/tdiss_R025_fac2.nc',
+!        cn_h_rough = 'INPUTS/h_RMS_topog_anom.nc', ! roughness file
+!        rn_kappa_tdiss = 0.00075398 ! x12 value  0.00006283,  ! wave number Jayne and Laurence 2004 value !282.74333! increasedwith x1500^2 x2
+!        tdiss_mindepth = 500.0 ! minimum depth to apply tdiss parameterisation 
+!!       rn_SO_enhance  = 250.0
+!!       rn_lat_SO_enhance = -69.7,
+
+      sn_tide_cnames(1) = 'Sa',
+      sn_tide_cnames(2) = 'Ssa',
+      sn_tide_cnames(3) = 'Mm',
+      sn_tide_cnames(4) = 'Msf',
+      sn_tide_cnames(5) = 'Mf',
+      sn_tide_cnames(6) = 'K1',
+      sn_tide_cnames(7) = 'Q1',
+      sn_tide_cnames(8) = 'O1',
+      sn_tide_cnames(9) = 'P1',
+      sn_tide_cnames(10) = 'S1',
+      sn_tide_cnames(11) = 'J1',
+      sn_tide_cnames(12) = 'M2',
+      sn_tide_cnames(13) = 'S2',
+      sn_tide_cnames(14) = '2N2',
+      sn_tide_cnames(15) = 'mu2',
+      sn_tide_cnames(16) = 'N2',
+      sn_tide_cnames(17) = 'nu2',
+      sn_tide_cnames(18) = 'L2',
+      sn_tide_cnames(19) = 'T2',
+      sn_tide_cnames(20) = 'K2',
+      sn_tide_cnames(21) = 'MKS2',
+      sn_tide_cnames(22) = 'lam2',
+      sn_tide_cnames(23) = 'R2',
+/
+
+&namdrg
+    ln_loglayer = .true.,
+/
+
+&namdrg_bot
+    rn_Cd0=2.5e-3,
+    ln_boost = .false.,
+/
+
+&nambbc
+    ln_trabbc = .true.,
+    cn_dir = './INPUT/',
+    sn_qgh = 'geothermal_heating_orca025ext_extrap40_v4.2.nc', -12, 'heatflow', .false., .true., 'yearly',
+             '', '', '',
+/
+
+&nambbl
+    ln_trabbl = .false.,
+    nn_bbl_adv  =  1,
+/
+
+&nameos
+    ln_teos10 = .true.,
+/
+
+&namtra_adv
+    ln_traadv_fct = .true.,
+    nn_fct_h = 4,
+    nn_fct_v = 4,
+/
+
+&namtra_ldf
+    ln_traldf_lap=.true.,
+    ln_traldf_triad=.true.,
+    rn_sw_triad     = 0,
+    ln_botmix_triad = .true.,
+    ln_triad_iso    = .true.,
+    nn_aht_ijk_t=20,
+    rn_slpmax=0.01,
+    rn_ud=0.011,
+/
+
+&namtra_eiv
+    ln_ldfeiv = .true.,
+    rn_ue = 1.5,
+    rn_le = 100.0,
+    nn_aei_ijk_t = 21,
+    ln_ldfeiv_dia = .true.,
+    nn_ldfeiv_shape = 2,
+/
+
+&namdyn_adv
+    ln_dynadv_vec = .true.,
+    nn_dynkeg = 1,
+/
+
+&namdyn_vor
+    ln_dynvor_een = .true.,
+/
+
+&namdyn_hpg
+    ln_hpg_djc  = .true.,
+      ln_hpg_djc_vnh = .true.,
+      ln_hpg_djc_vnv = .true.,
+/
+
+&namdyn_spg
+    ln_dynspg_ts = .true.,
+/
+
+&namdyn_ldf
+    ln_dynldf_blp = .true.,
+    ln_dynldf_lev = .true.,
+    nn_ahm_ijk_t = 20,
+    rn_uv = 0.0838,
+/
+
+&namzdf
+    ln_zad_aimp = .true.,
+    ln_zdfgls = .true.,
+    ln_zdfddm = .true.,
+    ln_zdfiwm = .true.,
+    nn_havtb = 1,
+/
+
+&namzdf_mldzint
+    nn_mld_diag=2,
+    sn_mld1=1,10.0,0.2,0.1,
+    sn_mld2=1,10.0,-0.2,0,
+/
+
+&namzdf_gls
+   rn_hsri       =  0.02
+   nn_z0_ice=1,
+   nn_mxlice=3,
+/
+
+&namzdf_iwm
+   ln_mevar    = .true.,   !  variable (T) or constant (F) mixing efficiency
+   ln_tsdiff   = .true.,    !  account for differential T/S mixing (T) or not (F)
+
+   cn_dir      = './INPUT/'      !  root directory for the iwm data location
+   !___________!_________________________!___________________!___________!_____________!________!___________!__________________!__________!_______________!
+   !           !  file name              ! frequency (hours) ! variable  ! time interp.!  clim  ! 'yearly'/ ! weights filename ! rotation ! land/sea mask !
+   !           !                         !  (if <0  months)  !   name    !   (logical) !  (T/F) ! 'monthly' !                  ! pairing  !    filename   !
+   sn_mpb      = 'zdfiwm_forcing_eORCA025.nc'  , -12.         , 'power_bot' , .false.  , .true. , 'yearly' , '' , ''  , ''
+   sn_mpc      = 'zdfiwm_forcing_eORCA025.nc'  , -12.         , 'power_cri' , .false.  , .true. , 'yearly' , '' , ''  , ''
+   sn_mpn      = 'zdfiwm_forcing_eORCA025.nc'  , -12.         , 'power_nsq' , .false.  , .true. , 'yearly' , '' , ''  , ''
+   sn_mps      = 'zdfiwm_forcing_eORCA025.nc'  , -12.         , 'power_sho' , .false.  , .true. , 'yearly' , '' , ''  , ''
+   sn_dsb      = 'zdfiwm_forcing_eORCA025.nc'  , -12.         , 'scale_bot' , .false.  , .true. , 'yearly' , '' , ''  , ''
+   sn_dsc      = 'zdfiwm_forcing_eORCA025.nc'  , -12.         , 'scale_cri' , .false.  , .true. , 'yearly' , '' , ''  , ''
+/
+
+&namctl
+    sn_cfctl%l_runstat = .true.,
+    ln_timing = .true.,
+    ln_diacfl = .true.,
+/
+
+&namtrd
+    ln_tra_trd = .true.,
+/


### PR DESCRIPTION
 # Add `namelist_cfg_ERA5_se` in `eORCA025`

This one is a copy of `namelist_cfg_ERA5` to which i've changed all what differs between `namelist_cfg_JRA` and `namelist_cfg_JRA_se` 

The only diff left between `namelist_cfg_ERA5_se` and `namelist_cfg_JRA_se` is identical to the non `se` namelist difference : 
* namsbc_blk
* namtrd 

see the diff bellow :
Shelf enabled namelists :  
|| ERA5 - se   || JRA - se ||
<img width="1888" height="944" alt="image" src="https://github.com/user-attachments/assets/ebfe8aa9-39f6-4886-824e-28a6f2a0e45d" />

normal namelists : 
|| ERA5     || JRA  || 
<img width="1888" height="944" alt="image" src="https://github.com/user-attachments/assets/0afe351e-2cad-46c8-8707-cb0f9d80292f" />

If i got it right, that should be it!       
still missing the internal waves, but this is for another issue/merge-request if needed ( Is it ready ? how do i activate that ? )

@jdha would you be happy to review it ? 
does that look OK 

