### PR TITLE
116 refactor era5 forcing workflow to support nrt updates

### DIFF
--- a/scripts/FORCING/ERA5v1/README.md
+++ b/scripts/FORCING/ERA5v1/README.md
@@ -28,9 +28,9 @@ In the following sections, we will discuss how to perform these steps in detail 
 
 ## 1. Downloading ERA-5 Atmospheric Fields
 
-Inside the `NOC_Near_Present_Day/scripts/FORCING/ERA5v1/` directory, users will find a bash script `run_download_ERA5_forcing.sh` to automate the downloading of ERA-5 data from the Copernicus Climate Data Store. 
+Inside the `NOC_Near_Present_Day/scripts/FORCING/ERA5v1/` directory, users will find a SLURM job script `run_download_ERA5_forcing.slurm` to automate the downloading of ERA-5 data from the Copernicus Climate Data Store. 
 
-One executing `run_download_ERA5_forcing.sh`, it calls the `download_ERA5_forcing.py` Python script, which (by default) downloads the following variables from the specified input `year` to present:
+On submitting the `run_download_ERA5_forcing.slurm` job script, it calls the `download_ERA5_forcing.py` Python script, which (by default) downloads the following variables from the specified input `year` to present:
 
 - 2m_temperature
 - 2m_dewpoint_temperature
@@ -46,13 +46,13 @@ One executing `run_download_ERA5_forcing.sh`, it calls the `download_ERA5_forcin
 
 Each variable is downloaded for the entire globe at hourly temporal resolution & stored in a single netCDF file per month per variable.
 
-These original ERA-5 variable netCDF files are stored according to their year in the `/dssgfs01/scratch/npd/forcing/ERA5/original/` directory and the `/dssgfs01/scratch/npd/forcing/ERA5/original_latest/` directory for the latest 3-months (since these are subject to change). 
+These original ERA-5 variable netCDF files are stored according to their year in the `/dssgfs01/scratch/npd/forcing/ERA5/original/` directory and the `/dssgfs01/scratch/npd/forcing/ERA5/original_latest/` directory for the latest 3-months (since these are subject to change - ERA5T dataset). 
 
 ## 2. Preprocessing ERA-5 Atmospheric Fields
 
-Once we completed downloading our ERA-5 atmospheric forcing files using the `run_download_ERA5_forcing.sh` script, we next need to pre-process these fields.
+Once we have completed downloading our ERA-5 atmospheric forcing files using the `run_download_ERA5_forcing.slurm` job script, we next need to pre-process these atmospheric fields.
 
-There are three steps to pre-processing each ERA-5 variable netCDF file, all of which are perfomed by the the `run_preprocess_ERA5_forcing_original.slurm` and `run_preprocess_ERA5_forcing_original_latest.slurm` scripts.
+There are three steps to pre-processing each ERA-5 variable stored in individual netCDF files, all of which are perfomed by the the `run_preprocess_ERA5_forcing_original.slurm` and `run_preprocess_ERA5_forcing_original_latest.slurm` job scripts.
 
 1. All land grid points in the ERA-5 forcing field are flood filled using a land-sea mask created using the `create_land_sea_mask.py` script and the `ifthen` and `fillmiss3` operations available in the `cdo` library.
 
@@ -87,49 +87,25 @@ In both cases, the resulting monthly bias corrected 2 m air temperature netCDF f
 
 We first need to create symbolic links to all preprocessed ERA-5 atmospheric forcing files, excluding the bias corrected 2 m air temperature files.
 
-**Note:** These commands should be performed inside the `/dssgfs01/scratch/npd/forcing/ERA5_t2m_adj/all_fields/` directory.
+To do this, we can use the `run_create_links_ERA5_t2m_adj.slurm` script on the Anemone HPC, which follows the steps below:
 
-```bash
-# Define NEMO forcing variables, excluding 2m_temperature
-vars = ('2m_dewpoint_temperature' 'mean_sea_level_pressure' 'mean_surface_downward_long_wave_radiation_flux' 'mean_total_precipitation_rate' '10m_u_component_of_wind' '10m_v_component_of_wind' '2m_temperature' 'mean_snowfall_rate' 'mean_surface_downward_short_wave_radiation_flux')
+1. Create symbolic links to all ERA-5 forcing variables, including adjusted 2 m temperature for the specified `year`:
 
-# Create symbolic links:
-for var in ${vars[*]}; do
-    ln -s /dssgfs01/scratch/npd/forcing/ERA5/preprocessed/????/${var}/*nc .
-done
-```
+2. Update date string formatting to replace "_20" -> "_y20" and "-" -> "m".
 
-For the bias corrected 2 m air temperature, we use the following path instead:
-
-```bash
-ln -s /dssgfs01/scratch/npd/forcing/ERA5_t2m_adj/????/*.nc .
-```
-
-Next, we need to update the date format of the preprocessed links to be read by the surface boundary condition module in NEMO:
-
-```bash
-# Fix date format
-rename _19 _y19 *nc
-rename _20 _y20 *nc
-rename - m *nc
-```
-
-Finally, we need to rename the variable names within the links to their shorter standard names:
-
-```bash
-# Rename with variable names
-rename 10m_u_component_of_wind u10 10m_u_component_of_wind*nc
-rename 10m_v_component_of_wind v10 10m_v_component_of_wind*nc
-rename 2m_dewpoint_temperature d2m 2m_dewpoint_temperature*nc
-rename 2m_temperature t2m 2m_temperature*nc
-rename mean_sea_level_pressure msl mean_sea_level_pressure*nc
-rename mean_snowfall_rate msr mean_snowfall_rate*nc
-rename mean_surface_downward_long_wave_radiation_flux msdwlwrf mean_surface_downward_long_wave_radiation_flux*nc
-rename mean_surface_downward_short_wave_radiation_flux msdwswrf mean_surface_downward_short_wave_radiation_flux*nc
-rename mean_total_precipitation_rate mtpr mean_total_precipitation_rate*nc
-```
+3. Rename all symbolic links to use short-form variable names (e.g., "10m_u_component_of_wind" -> "u10").
 
 We have now completed preparing the ERA-5 atmospheric forcing fields & we can perform a NOC Near-Present Day simulation by creating a further link to the `/dssgfs01/scratch/npd/forcing/ERA5_t2m_adj/all_fields` inside our NEMO run directory (this link will then be referenced directly in our `namelist_cfg` file).
+
+# Appendix: Near-Real Time ERA-5 Forcing Files
+
+We cannot run NOC NPD configurations with incomplete monthly forcing files since NEMO verifies the length of the record dimension against the present month using its internal calendar in the SBC module.
+
+To overcome this, we can use the `extend_ERA5_preprocessed_latest.py` script to fill all missing data along the record dimension in our preprocessed ERA-5 forcing variables with NaN values.
+
+This will allow us to run a partial month using a NOC NPD configuration, but note that the simulation is expected to fail on reaching the fill values as this represents unphysical forcing of the ocean by the atmosphere.
+
+To ensure 5-day mean output fields are still produces, users should modify the `sync_freq` to increase the frequency with which XIOS writes 5-day means to netCDF output files. The default 15-day value will result in missing netCDF files if unmodified.
 
 ## Contacts
 

--- a/scripts/FORCING/ERA5v1/apply_ERA5_t2m_si_adjustment.py
+++ b/scripts/FORCING/ERA5v1/apply_ERA5_t2m_si_adjustment.py
@@ -15,7 +15,7 @@ import xarray as xr
 
 # -- Configure Argument Parser -- #
 # Define the argument parser:
-parser = argparse.ArgumentParser(description='Apply monthly climatological correction to ERA-5 2m air temperature at 3-hourly frequency above sea ice.')
+parser = argparse.ArgumentParser(description='Apply monthly climatological correction to ERA-5 2m air temperature at 1-hourly frequency above sea ice.')
 # Define input arguments:
 parser.add_argument('-y','--year', help='Year to apply monthly climatological correction.', type=int, required=True)
 parser.add_argument('-o','--outdir', help='Directory to save climatologically corrected ERA-5 2m temperature netCDF files.', default="/dssgfs01/scratch/npd/forcing/ERA5_t2m_adj/")
@@ -93,12 +93,12 @@ else:
 
 # -- Define File Paths -- #
 # ERA-5 2m temperature input directory:
-t2m_fpath = f"/dssgfs01/scratch/npd/forcing/ERA5/preprocessed/{yr}/2m_temperature/*.nc"
+t2m_fpath = f"/dssgfs01/scratch/npd/forcing/ERA5/preprocessed_latest/{yr}/2m_temperature/*.nc"
 t2m_files = sorted(glob.glob(t2m_fpath))
 n_files = len(t2m_files)
 
 # ERA-5 sea ice cover input directory:
-sic_fpath = f"/dssgfs01/scratch/npd/forcing/ERA5/original/{yr}/sea_ice_cover/*.nc"
+sic_fpath = f"/dssgfs01/scratch/npd/forcing/ERA5/original_latest/{yr}/sea_ice_cover/*.nc"
 sic_files = sorted(glob.glob(sic_fpath))
 
 # Check number of t2m and sic files match:
@@ -115,48 +115,66 @@ months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", 
 # -- Apply Climatological Correction -- #
 # Iterate over monthly 2m temperature and sea ice cover files:
 for n in range(n_files):
-    # Open 2m temperature dataset:   
-    ds_t2m = xr.open_dataset(t2m_files[n])
-    if ("valid_time" in ds_t2m.coords):
-        ds_t2m = ds_t2m.rename({"valid_time": "time"})
-    logging.info(f"Completed: Read {t2m_files[n]}")
 
-    # Open sea ice conc. dataset:   
-    ds_sic = xr.open_dataset(sic_files[n])
-    if ("valid_time" in ds_sic.coords):
-        ds_sic = ds_sic.rename({"valid_time": "time"})
-    logging.info(f"Completed: Read {sic_files[n]}") 
-
-    # Open ERA-5 monthly climatological adjustment file:
-    t2m_adj_dir = "/dssgfs01/scratch/atb299/ERA5_adjustment/2m_temperature"
-    if (n == 1) & (len(ds_t2m.time) == 696): 
-       logging.info(f"In Progress: Applying {months[n]} {yr} Leap Year Adjustment.")
-       ds_bias = xr.open_dataset(f"{t2m_adj_dir}/2m_temperature-{f'{n+1:02d}'}_LY.nc")
-    else:
-        logging.info(f"In Progress: Applying {months[n]} {yr} Regular Adjustment.")
-        ds_bias = xr.open_dataset(f"{t2m_adj_dir}/2m_temperature-{f'{n+1:02d}'}.nc")
-
-    # Replace time values with input t2m data:
-    ds_bias['time'] = ds_t2m['time']
-
-    # Apply climatological correction where sea ice exists (i.e., sic > 0):
-    ds_t2m_adj = xr.where(ds_sic['siconc'] > 0, ds_t2m['t2m'] - ds_bias['t2m'], ds_t2m['t2m']).to_dataset(name='t2m')
-
-    # Add attributes of original dataset to adjusted dataset:
-    ds_t2m_adj.attrs = ds_t2m.attrs
-
-    logging.info("Completed: Applied monthly climatological correction to ERA-5 2m temperature.")
-
-    # Adjust dtypes for latest ERA-5 data:
-    if (yr >= 2024):
-        ds_t2m_adj['t2m'] = ds_t2m_adj['t2m'].astype('float')
-
-    # -- Write Climatologically Corrected Data -- #
-    # Define original encoding for output netCDF file:
-    encoding = get_encoding(ds_t2m, yr)
     # Defining output file path:
     outfile = f"{outdir}/2m_temperature_{yr}-{f'{n+1:02d}'}.nc"
-    # Write to netCDF file:
-    logging.info(f"In Progress: Producing {months[n]} {yr} climatologically corrected ERA-5 2m temperature.")
-    ds_t2m_adj.to_netcdf(outfile, encoding=encoding, unlimited_dims='time')
-    logging.info(f"Completed: Produced {months[n]} {yr} climatologically corrected ERA-5 2m temperature in {outfile}")
+
+    if os.path.exists(outfile):
+        logging.info(f"Skipping {months[n]} {yr}: climatologically corrected ERA-5 2m temperature already exists in {outfile}.")
+        continue
+
+    else:
+        logging.info(f"In Progress: Applying monthly climatological correction to {months[n]} {yr} ERA-5 2m temperature.")
+        # Open 2m temperature dataset:   
+        ds_t2m = xr.open_dataset(t2m_files[n])
+        if ("valid_time" in ds_t2m.coords):
+            ds_t2m = ds_t2m.rename({"valid_time": "time"})
+        logging.info(f"Completed: Read {t2m_files[n]}")
+
+        # Open sea ice conc. dataset:   
+        ds_sic = xr.open_dataset(sic_files[n])
+        if ("valid_time" in ds_sic.coords):
+            ds_sic = ds_sic.rename({"valid_time": "time"})
+        if len(ds_sic['time']) != len(ds_t2m['time']):
+            logging.info(f"t2m = {len(ds_t2m['time'])}, sic = {len(ds_sic['time'])}")
+            ds_sic = ds_sic.isel(time=slice(0, len(ds_t2m['time'])))
+            logging.info(f"Completed: Subset {months[n]} {yr} sea ice cover to match ERA-5 2m temperature.")
+        logging.info(f"Completed: Read {sic_files[n]}") 
+
+        # Open ERA-5 monthly climatological adjustment file:
+        t2m_adj_dir = "/dssgfs01/scratch/atb299/ERA5_adjustment/2m_temperature"
+        if (n == 1) & (len(ds_t2m.time) == 696): 
+            logging.info(f"In Progress: Applying {months[n]} {yr} Leap Year Adjustment.")
+            ds_bias = xr.open_dataset(f"{t2m_adj_dir}/2m_temperature-{f'{n+1:02d}'}_LY.nc")
+        else:
+            logging.info(f"In Progress: Applying {months[n]} {yr} Regular Adjustment.")
+            ds_bias = xr.open_dataset(f"{t2m_adj_dir}/2m_temperature-{f'{n+1:02d}'}.nc")
+
+        # Align ERA-5 climatological adjustment time dimension to input t2m data:
+        if len(ds_bias['time']) > len(ds_t2m['time']):
+            logging.info(f"t2m = {len(ds_t2m['time'])}, bias = {len(ds_bias['time'])}")
+            ds_bias = ds_bias.isel(time=slice(0, len(ds_t2m['time'])))
+            logging.info(f"Completed: Subset {months[n]} {yr} climatological adjustment to match ERA-5 2m temperature.")
+
+        # Replace time values with input t2m data:
+        ds_bias['time'] = ds_t2m['time']
+
+        # Apply climatological correction where sea ice exists (i.e., sic > 0):
+        ds_t2m_adj = xr.where(ds_sic['siconc'] > 0, ds_t2m['t2m'] - ds_bias['t2m'], ds_t2m['t2m']).to_dataset(name='t2m')
+
+        # Add attributes of original dataset to adjusted dataset:
+        ds_t2m_adj.attrs = ds_t2m.attrs
+
+        logging.info("Completed: Applied monthly climatological correction to ERA-5 2m temperature.")
+
+        # Adjust dtypes for latest ERA-5 data:
+        if (yr >= 2024):
+            ds_t2m_adj['t2m'] = ds_t2m_adj['t2m'].astype('float')
+
+        # -- Write Climatologically Corrected Data -- #
+        # Define original encoding for output netCDF file:
+        encoding = get_encoding(ds_t2m, yr)
+        # Write to netCDF file:
+        logging.info(f"In Progress: Writing {months[n]} {yr} climatologically corrected ERA-5 2m temperature to {outfile}.")
+        ds_t2m_adj.to_netcdf(outfile, encoding=encoding, unlimited_dims='time')
+        logging.info(f"Completed: Writing {months[n]} {yr} climatologically corrected ERA-5 2m temperature in {outfile}")

--- a/scripts/FORCING/ERA5v1/download_ERA5_forcing.py
+++ b/scripts/FORCING/ERA5v1/download_ERA5_forcing.py
@@ -19,13 +19,13 @@ from tenacity import retry, stop_after_attempt, wait_fixed
 
 # -- Configure Argument Parser -- #
 # Define the argument parser:
-parser = argparse.ArgumentParser(description='Download ERA-5 atmospheric forcing data from the Copernicus Climate Data Store at 3-hour frequency in monthly netCDF output files.')
+parser = argparse.ArgumentParser(description='Download ERA-5 atmospheric forcing data from the Copernicus Climate Data Store at 1-hour frequency in monthly netCDF output files.')
 # Define input arguments:
 parser.add_argument('-y','--year', help='Year to start ERA-5 monthly download from.', required=True, type=int, default=2025)
 parser.add_argument('-s','--savedir', help='Directory to save historic ERA-5 monthly netCDF files.', required=True)
 parser.add_argument('-l','--latestdir', help='Directory to save latest 3-months of ERA-5 monthly netCDF files.', required=True)
-parser.add_argument('-v','--variables', help='List of ERA-5 variables to download.', required=False, nargs='+', default=['2m_temperature', '2m_dewpoint_temperature', '10m_u_component_of_wind', '10m_v_component_of_wind',
- 'mean_total_precipitation_rate', 'mean_snowfall_rate', 'mean_surface_downward_short_wave_radiation_flux', 'mean_surface_downward_long_wave_radiation_flux', 'mean_sea_level_pressure', 'sea_ice_cover', 'sea_surface_temperature'])
+parser.add_argument('-e','--enddate', help='Final date to end ERA-5 monthly download.', required=False, type=str, default=None)
+parser.add_argument('-v','--variables', help='List of ERA-5 variables to download.', required=False, nargs='+', default=['2m_temperature', '2m_dewpoint_temperature', '10m_u_component_of_wind', '10m_v_component_of_wind', 'mean_total_precipitation_rate', 'mean_snowfall_rate', 'mean_surface_downward_short_wave_radiation_flux', 'mean_surface_downward_long_wave_radiation_flux', 'mean_sea_level_pressure', 'sea_ice_cover', 'sea_surface_temperature'])
 
 # --- Configure Logging --- #
 logging.basicConfig(
@@ -46,12 +46,19 @@ ini_year = args['year']
 save_dir = args['savedir']
 latest_dir = args['latestdir']
 variables = args['variables']
+end_date = args['enddate']
+if end_date is not None:
+    end_date = datetime.datetime.strptime(end_date, "%Y-%m-%d").date()
 
 # -- Define download_ERA5_data() -- #
 @retry(stop=stop_after_attempt(3), wait=wait_fixed(10))
-def download_ERA5_data(client, date:datetime.date, variable:str, outfile:str) -> None:
+def download_ERA5_data(client,
+                       date:datetime.date,
+                       variable:str,
+                       outfile:str
+                       ) -> None:
     """
-    Download ERA-5 3-hourly data on single levels using the Copernicus
+    Download ERA-5 1-hourly data on single levels using the Copernicus
     Climate Data Store (CDS) API.
 
     Parameters:
@@ -117,7 +124,11 @@ def download_ERA5_data(client, date:datetime.date, variable:str, outfile:str) ->
 
 # -- Prepare Dates -- #
 ini_date = date(year=ini_year, month=1, day=1)
-final_date = date.today()
+# Optionally define custom end date for partial month download:
+if end_date is not None:
+    final_date = end_date
+else:
+    final_date = date.today()
 # Excluding current month - downloads latest full month of data:
 dates_monthly = np.arange(ini_date, final_date, dtype='datetime64[M]').astype(datetime.date)
 

--- a/scripts/FORCING/ERA5v1/extend_ERA5_preprocessed_latest.py
+++ b/scripts/FORCING/ERA5v1/extend_ERA5_preprocessed_latest.py
@@ -1,0 +1,143 @@
+"""
+extend_ERA5_preprocessed_latest.py
+
+Description: This script extends the valid_time dimension of the latest month of ERA5 preprocessed
+data to ensure compatibility with fldread routine in NEMO SBC - which requires a full month of data.
+
+Missing time steps are filled with NaN values.
+
+Created By: Ollie Tooth (oliver.tooth@noc.ac.uk)
+"""
+# -- Import Dependencies -- #
+import os
+import logging
+import xarray as xr
+import numpy as np
+
+
+# -- Define main function to extend ERA5 preprocessed data -- #
+def main(filedir_latest: str = "/dssgfs01/scratch/npd/forcing/ERA5/preprocessed_latest",
+         filedir_t2m_adj: str = "/dssgfs01/scratch/npd/forcing/ERA5_t2m_adj",
+         year: int = 2026,
+         month: int = 5,
+         variable_list: list = ["2m_temperature", "2m_dewpoint_temperature",
+                                "mean_sea_level_pressure",
+                                "mean_surface_downward_long_wave_radiation_flux",
+                                "mean_surface_downward_short_wave_radiation_flux",
+                                "mean_snowfall_rate", "mean_total_precipitation_rate",
+                                "10m_u_component_of_wind", "10m_v_component_of_wind"]
+         ) -> None:
+    """
+    Extend the valid_time dimension of the latest month of ERA5 preprocessed data.
+
+    Parameters:
+    -----------
+    filedir_latest: str
+        Directory of latest preprocessed ERA5 data to be extended.
+    filedir_t2m_adj: str
+        Directory of adjusted ERA5 2m temperature data to be extended.
+    year: int
+        Year of the latest month of ERA5 data to be extended.
+    month: int
+        Month of the latest month of ERA5 data to be extended.
+    variable_list: list
+        List of ERA5 variables to extend.
+    """
+    # --- Configure Logging --- #
+    logging.basicConfig(
+        filename="extend_ERA5_preprocessed_latest.log",
+        encoding="utf-8",
+        filemode="w",
+        format="{asctime} - {levelname} - {message}",
+        style="{",
+        datefmt="%Y-%m-%d %H:%M",
+        level=logging.INFO,
+        )
+    
+    # -- Define Variable Mapping -- #
+    var_map = {
+        "2m_temperature": "t2m",
+        "2m_dewpoint_temperature": "d2m",
+        "mean_sea_level_pressure": "msl",
+        "mean_surface_downward_long_wave_radiation_flux": "msdwlwrf",
+        "mean_surface_downward_short_wave_radiation_flux": "msdwswrf",
+        "mean_snowfall_rate": "msr",
+        "mean_total_precipitation_rate": "mtpr",
+        "10m_u_component_of_wind": "u10",
+        "10m_v_component_of_wind": "v10"
+    }
+
+    logging.info(f"=== Extending ERA5 preprocessed data for {year}-{month:02d} ===")
+    for var in variable_list:
+        logging.info(f"-> In Progress: Extending ERA5 preprocessed variable: {var}")
+        # -- Define Target Directory -- #
+        if var == "2m_temperature":
+            filedir = f"{filedir_t2m_adj}/{year}"
+            filedir_ref = f"{filedir_t2m_adj}/{year - 1}"
+            time_name = "time"
+        else:
+            filedir = f"{filedir_latest}/{year}/{var}"
+            filedir_ref = f"{filedir_latest.replace('preprocessed_latest', 'preprocessed')}/{year - 1}/{var}"
+            time_name = "valid_time"
+
+        # -- Check if Output Filepath Exists -- #
+        filepath_out = f"{filedir}/{var}_{year}-{month:02d}_extended.nc"
+        if os.path.isfile(filepath_out):
+            logging.info(f"Skipping file: {filepath_out} already exists.")
+            continue
+
+        # -- Open Reference ERA5 Dataset -- #
+        filepath_ref = f"{filedir_ref}/{var}_{year - 1}-{month:02d}.nc"
+        ds_ref = xr.open_dataset(filepath_ref)
+        logging.info(f"-> Completed: Opened reference ERA5 dataset: {filepath_ref}")
+
+        # -- Open Partial ERA5 Dataset -- #
+        filepath_partial = f"{filedir}/{var}_{year}-{month:02d}.nc"
+        ds_partial = xr.open_dataset(filepath_partial)
+        logging.info(f"-> Completed: Opened latest partial ERA5 dataset: {filepath_partial}")
+
+        # -- Define Empty ERA5 Dataset for Missing Time Steps -- #
+        if len(ds_partial[time_name]) == len(ds_ref[time_name]):
+            raise ValueError(f"ERA5 preprocessed variable {var} for {year}-{month:02d} already contains a full month of data.")
+        nvt = len(ds_partial[time_name])
+        # Select outstanding time steps from reference dataset and fill with NaN values:
+        ds_ref = ds_ref.isel({time_name: slice(nvt, None)})
+        ds_ref[var_map[var]].data = np.full_like(ds_ref[var_map[var]].data, fill_value=np.nan)
+
+        # -- Concatenate Partial and Reference Datasets -- #
+        ds_out = xr.concat([ds_partial, ds_ref], dim=time_name)
+
+        # -- Write Extended Dataset to File -- #
+        ds_out.to_netcdf(filepath_out)
+        logging.info(f"-> Completed: Saved extended ERA5 preprocessed variable {var} to netCDF file: {filepath_out}")
+        logging.info("  ======  ")
+
+if __name__ == "__main__":
+    # ========== Input Arguments ========== #
+    # Directory of latest preprocessed ERA5 data to be extended:
+    filedir_latest = "/dssgfs01/scratch/npd/forcing/ERA5/preprocessed_latest"
+
+    # Directory of adjusted ERA5 2m temperature data to be extended:
+    filedir_t2m_adj = "/dssgfs01/scratch/npd/forcing/ERA5_t2m_adj"
+
+    # Define year and month of the latest month of ERA5 data to be extended:
+    year = 2026
+    month = 5
+
+    # Define list of ERA5 variables to extend:
+    variable_list = ["2m_temperature", "2m_dewpoint_temperature",
+                    "mean_sea_level_pressure",
+                    "mean_surface_downward_long_wave_radiation_flux",
+                    "mean_surface_downward_short_wave_radiation_flux",
+                    "mean_snowfall_rate", "mean_total_precipitation_rate",
+                    "10m_u_component_of_wind", "10m_v_component_of_wind"
+                    ]
+    # ========== Input Arguments ========== #
+    
+    # -- Run Main Function -- #
+    main(filedir_latest=filedir_latest,
+         filedir_t2m_adj=filedir_t2m_adj,
+         year=year,
+         month=month,
+         variable_list=variable_list
+         )

--- a/scripts/FORCING/ERA5v1/run_apply_t2m_si_adjust.slurm
+++ b/scripts/FORCING/ERA5v1/run_apply_t2m_si_adjust.slurm
@@ -17,12 +17,12 @@
 module load NEMO/prg-env
 export I_MPI_SHM=icx
 
-source /home/otooth/miniconda3/etc/profile.d/conda.sh
+source /dssgfs01/working/otooth/miniforge3/bin/activate
 conda activate /dssgfs01/working/otooth/conda_envs/env_npd_era5
 
 # -- Process Single Year -- #
 # Define years to process:
-yr=2025
+yr=2026
 
 echo "================================================="
 echo "In Progress: Applying Climatological Adjustment to ${yr} ..."

--- a/scripts/FORCING/ERA5v1/run_apply_t2m_si_adjust_MY.slurm
+++ b/scripts/FORCING/ERA5v1/run_apply_t2m_si_adjust_MY.slurm
@@ -17,12 +17,12 @@
 module load NEMO/prg-env
 export I_MPI_SHM=icx
 
-source /home/otooth/miniconda3/etc/profile.d/conda.sh
+source /dssgfs01/working/otooth/miniforge3/bin/activate
 conda activate /dssgfs01/working/otooth/conda_envs/env_npd_era5
 
 # -- Process -P N Years Simultaneously -- #
 # Define years to process:
-yrs=($(seq 2023 2025))
+yrs=($(seq 2023 2026))
 
 echo "================================================="
 echo "In Progress: Applying Climatological Adjustment to ${yrs} ..."

--- a/scripts/FORCING/ERA5v1/run_create_links_ERA5_t2m_adj.slurm
+++ b/scripts/FORCING/ERA5v1/run_create_links_ERA5_t2m_adj.slurm
@@ -1,0 +1,63 @@
+#!/bin/bash
+#SBATCH --job-name=create_era5_t2m_adj_links
+#SBATCH --time=00:05:00
+#SBATCH --partition=test
+#SBATCH --ntasks=1
+
+# ------------------------------------------------------------
+# run_create_links_ERA5_t2m_adj.slurm
+# Description: Create symbolic links for climatologically
+# adjusted ERA-5 2m temperature files.
+#
+# Created By: Ollie Tooth (oliver.tooth@noc.ac.uk)
+# Last Edited By: Ollie Tooth (oliver.tooth@noc.ac.uk)
+# ------------------------------------------------------------
+set -euo pipefail
+
+# ==== Input Parameters ==== #
+# Year to prepare symbolic links for:
+year=2026
+
+# Input directory containing preprocessed ERA-5 monthly .nc files:
+inputdir="/dssgfs01/scratch/npd/forcing/ERA5/preprocessed_latest"
+
+# Directory to save historic ERA-5 monthly .nc files:
+linksdir="/dssgfs01/scratch/npd/forcing/ERA5_t2m_adj/all_fields/"
+
+# === Create Symbolic Links for Climatologically Adjusted ERA-5 2m Temperature === #
+echo "In Progress: Creating symbolic links for climatologically adjusted ERA-5 2m temperature files for ${year} ..."
+
+# Move to directory of symbolic links for ERA-5 adjusted forcing:
+mkdir -p $linksdir
+cd $linksdir
+
+# Define NEMO forcing variables, excluding 2m_temperature:
+vars="2m_dewpoint_temperature mean_sea_level_pressure mean_surface_downward_long_wave_radiation_flux mean_total_precipitation_rate 10m_u_component_of_wind 10m_v_component_of_wind mean_snowfall_rate mean_surface_downward_short_wave_radiation_flux"
+
+# Create symbolic links for preprocessed ERA-5 variables:
+for var in ${vars}; do
+    ln -s ${inputdir}/${year}/${var}/*nc .
+done
+
+# Create symbolic links for climatologically adjusted ERA-5 2m temperature:
+ln -s /dssgfs01/scratch/npd/forcing/ERA5_t2m_adj/${year}/2m_temperature*.nc .
+
+# === Update File Naming Format === #
+# Update ERA-5 date format (i.e., _2025-01 -> _y2025m01):
+# rename _19 _y19 *nc
+rename _20 _y20 *nc
+rename - m *nc
+
+# Update ERA-5 variable names to short format:
+rename 10m_u_component_of_wind u10 10m_u_component_of_wind*nc
+rename 10m_v_component_of_wind v10 10m_v_component_of_wind*nc
+rename 2m_dewpoint_temperature d2m 2m_dewpoint_temperature*nc
+rename 2m_temperature t2m 2m_temperature*nc
+rename mean_sea_level_pressure msl mean_sea_level_pressure*nc
+rename mean_snowfall_rate msr mean_snowfall_rate*nc
+rename mean_surface_downward_long_wave_radiation_flux msdwlwrf mean_surface_downward_long_wave_radiation_flux*nc
+rename mean_surface_downward_short_wave_radiation_flux msdwswrf mean_surface_downward_short_wave_radiation_flux*nc
+rename mean_total_precipitation_rate mtpr mean_total_precipitation_rate*nc
+
+echo "Completed: Created symbolic links for climatologically adjusted ERA-5 2m temperature files for ${year}."
+cd -

--- a/scripts/FORCING/ERA5v1/run_download_ERA5_forcing.slurm
+++ b/scripts/FORCING/ERA5v1/run_download_ERA5_forcing.slurm
@@ -1,0 +1,46 @@
+#!/bin/bash
+#SBATCH --job-name=download_era5_forcing
+#SBATCH --time=06:00:00
+#SBATCH --partition=compute
+#SBATCH --nodes=1
+#SBATCH --exclusive
+
+# ------------------------------------------------------------
+# run_download_ERA5_forcing.sh
+# Description: Download ERA-5 atmospheric forcing data for a
+# single year from the Copernicus Climate Data Store.
+#
+# Created By: Ollie Tooth (oliver.tooth@noc.ac.uk)
+# Last Edited By: Ollie Tooth (oliver.tooth@noc.ac.uk)
+# ------------------------------------------------------------
+set -euo pipefail
+
+# -- Load modules and activate conda environment -- #
+module purge
+source /dssgfs01/working/otooth/miniforge3/bin/activate
+conda activate /dssgfs01/working/otooth/conda_envs/env_npd_era5
+
+# ==== Input Parameters ==== #
+# Year to start ERA-5 monthly download from:
+year=2026
+
+# Optional: End date to include partial month download:
+end_date="2026-06-01"
+
+# Directory to save historic ERA-5 monthly .nc files:
+savedir=/dssgfs01/scratch/npd/forcing/ERA5/original/
+
+# Directory to save latest 3-months of ERA-5 monthly .nc files:
+latestdir=/dssgfs01/scratch/npd/forcing/ERA5/original_latest/
+
+# Variable list to download - default is all variables:
+# variables="2m_temperature 2m_dewpoint_temperature"
+
+# -- Download ERA-5 Atmospheric Forcing -- #
+echo "In Progress: Downloading ERA-5 atmospheric forcing data from ${year} to present..."
+
+# Using default variable list:
+# python3 download_ERA5_forcing.py --year ${year} --savedir ${savedir} --latestdir ${latestdir}
+python3 download_ERA5_forcing.py --year ${year} --savedir ${savedir} --latestdir ${latestdir} --enddate ${end_date}
+
+echo "Completed: Downloaded ERA-5 atmospheric forcing data from ${year} to present."

--- a/scripts/FORCING/ERA5v1/run_preprocess_ERA5_forcing_original.slurm
+++ b/scripts/FORCING/ERA5v1/run_preprocess_ERA5_forcing_original.slurm
@@ -1,6 +1,6 @@
 #!/bin/bash
 #SBATCH --job-name=preprocess_ERA5_original
-#SBATCH --time=04:00:00
+#SBATCH --time=06:00:00
 #SBATCH --partition=compute
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-core=1
@@ -29,8 +29,7 @@ export indir='/dssgfs01/scratch/npd/forcing/ERA5/original/'
 export outdir='/dssgfs01/scratch/npd/forcing/ERA5/preprocessed/'
 
 # -- Define Input Files -- #
-# TO DO: Update from start_year below to present.
-year=2025
+year=2026
 infiles=(${indir}${year}/{10m_u_component_of_wind,10m_v_component_of_wind,2m_dewpoint_temperature,2m_temperature,mean_sea_level_pressure,mean_snowfall_rate,mean_surface_downward_short_wave_radiation_flux,mean_surface_downward_long_wave_radiation_flux,mean_total_precipitation_rate}/*.nc)
 inf=${#infiles[*]}
 

--- a/scripts/FORCING/ERA5v1/run_preprocess_ERA5_forcing_original_latest.slurm
+++ b/scripts/FORCING/ERA5v1/run_preprocess_ERA5_forcing_original_latest.slurm
@@ -1,15 +1,15 @@
 #!/bin/bash
 #SBATCH --job-name=preprocess_ERA5_original_latest
-#SBATCH --time=04:00:00
+#SBATCH --time=06:00:00
 #SBATCH --partition=compute
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-core=1
-#SBATCH --mem-per-cpu=12G
+#SBATCH --mem-per-cpu=8G
 #SBATCH --ntasks-per-node=16
 #SBATCH --ntasks-per-socket=8
 
 # ------------------------------------------------------------
-# run_preprocess_ERA5_forcing_latest.slurm
+# run_preprocess_ERA5_forcing_original_latest.slurm
 # Description:
 # Perform flood filling, chunking and variable renaming for
 # latest ERA-5 1-hourly atmospheric forcing fields & save to
@@ -29,7 +29,7 @@ export indir='/dssgfs01/scratch/npd/forcing/ERA5/original_latest/'
 export outdir='/dssgfs01/scratch/npd/forcing/ERA5/preprocessed_latest/'
 
 # -- Define Input Files -- #
-year=2025
+year=2026
 infiles=(${indir}${year}/{10m_u_component_of_wind,10m_v_component_of_wind,2m_dewpoint_temperature,2m_temperature,mean_sea_level_pressure,mean_snowfall_rate,mean_surface_downward_short_wave_radiation_flux,mean_surface_downward_long_wave_radiation_flux,mean_total_precipitation_rate}/*.nc)
 inf=${#infiles[*]}
 
@@ -65,9 +65,9 @@ xargs -n 1 -P 16 <<< ${compfiles[*]} sh -c '${cdodir}/cdo -k auto -z zip_1 ifthe
 xargs -n 1 -P 16 <<< ${compfiles[*]} sh -c '${cdodir}/cdo -k auto -z zip_1 fillmiss3 ${masktemp}/${1} ${floodtemp}/${1}' bash
 echo "Completed: Flood filled ERA-5 forcing files."
 
-# -- Rechunking ERA-5 Forcing Fields -- #
 echo "================================================="
-xargs -n 1 -P 12 <<< ${compfiles[*]} sh -c 'ncks --mk_rec_dmn time --cnk_dmn longitude,24 --cnk_dmn latitude,24 --cnk_dmn time,1 --dfl_lvl 1 ${floodtemp}/${1} ${outdir}${1: -10: -6}/${1::-11}/${1}' bash
+echo "In Progress: Rechunking ERA-5 forcing files..."
+xargs -n 1 -P 6 <<< ${compfiles[*]} sh -c 'ncks --mk_rec_dmn time --cnk_dmn longitude,24 --cnk_dmn latitude,24 --cnk_dmn time,1 --dfl_lvl 1 ${floodtemp}/${1} ${outdir}${1: -10: -6}/${1::-11}/${1}' bash
 echo "Completed: Rechunked ERA-5 forcing files."
 
 # -- Renaming Variables ERA-5 Forcing Fields -- #


### PR DESCRIPTION
### Refactor ERA5 atmospheric forcing workflow to support near-real time updates to NOC NPD.

- [x] Add slurm job scripts for download tasks.
- [x] Add script to create links for standard and bias corrected ERA5 datasets.
- [x] Add support for extending the valid_time record dimension of monthly forcing files to allow for near-real time NPD runs.
- [x] Update `README.md` documentation on the `FORCING` workflow.